### PR TITLE
i18n

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -130,5 +130,17 @@
     "webmailPreviewContinue": {
       "message": "Continue",
       "description": "Button text to continue with safely previewing a link"
+    },
+    "reportEmailReportedAlready": {
+      "message": "Reported to PhishDetect",
+      "description": "Text shown when trying to report an email that was already reported."
+    },
+    "reportEmailReport": {
+      "message": "Report to PhishDetect",
+      "description": "Label for the report button"
+    },
+    "reportEmailConfirm": {
+      "message": "Are you sure you want to report this email to your PhishDetect Node administrator?",
+      "description": "Confirmation message when reporting an email"
     }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -106,5 +106,9 @@
     "webmailWarningHelp": {
       "message": "For more information visit our help page:",
       "description": "Label for a link to the help page."
+    },
+    "webmailLinkWarning": {
+      "message": "PhishDetect Warning: this link is malicious!",
+      "description": "Warning text for a known malicious link"
     }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,4 +1,8 @@
 {
+    "manifestDescription": {
+      "message": "Anti-phishing browser extension. Scan suspicious pages and links.",
+      "description": "Displayed in the Chrome/FF store and about:extensions"
+    },
     "popupScanThisPage": {
       "message": "Scan this page!",
       "description": "Displayed on the popup page button."

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -86,5 +86,25 @@
     "contextMenuScanLink": {
       "message": "Scan this link for phishing",
       "description": "Text for context menu option to scan a link"
+    },
+    "webmailWarningWarning": {
+      "message": "Warning",
+      "description": "Label for a warning message"
+    },
+    "webmailWarningPleaseBeCautious": {
+      "message": "Please be cautious!",
+      "description": "Secondary text for a warning message"
+    },
+    "webmailWarningSender": {
+      "message": "The email was sent by a known malicious address.",
+      "description": "Explanation of a webmail warning event"
+    },
+    "webmailWarningLinks": {
+      "message": "The email contains known malicious links.",
+      "description": "Explanation of a webmail warning event"
+    },
+    "webmailWarningHelp": {
+      "message": "For more information visit our help page:",
+      "description": "Label for a link to the help page."
     }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,0 +1,74 @@
+{
+    "popupScanThisPage": {
+      "message": "Scan this page!",
+      "description": "Displayed on the popup page button."
+    },
+    "popupSettings": {
+      "message": "Settings",
+      "description": "Label for a button on the popup page to open the settings page."
+    },
+    "popupHelp": {
+      "message": "Help",
+      "description": "Help link on popup page."
+    },
+    "optionsDescription": {
+      "message": "Through this form you can decide which PhishDetect Node to connect to.",
+      "description": "Description shown at the top of the options page"
+    },
+    "optionsNode": {
+      "message": "Your preferred PhishDetect Node:",
+      "description": "Label for the PhishDetect node form field on the options page"
+    },
+    "optionsEnableWebmail": {
+      "message": "Enable Webmails integration",
+      "description": "Label for checkbox to enable webmail integration."
+    },
+    "optionsReportAlerts": {
+      "message": "Report alerts to PhishDetect Node",
+      "description": "Label for checkbox to enable reporting of alerts."
+    },
+    "optionsContact": {
+      "message": "If you wish, you can leave your contact details:",
+      "description": "Label for contact details field."
+    },
+    "optionsSave": {
+      "message": "Save",
+      "description": "Label for save button on options page."
+    },
+    "optionsRestore": {
+      "message": "Restore Defaults",
+      "description": "Link to restore default values on the options page."
+    },
+    "warningWarning": {
+      "message": "Warning",
+      "description": "Title for a warning page when opening a dangerous url."
+    },
+    "warningAway": {
+      "message": "TAKE ME AWAY",
+      "description": "Text for button to abort opening a dangerous url"
+    },
+    "apikeyThankyou": {
+      "message": "Thank you for participating to PhishDetect closed beta program!",
+      "description": "Paragraph text thanking the user."
+    },
+    "apikeyGetToken": {
+      "message": "In order to continue using the PhishDetect Browser Extension, you will be required to enter a valid secret token. You don't have one yet?",
+      "description": "Paragraph text. Following this text is a link to register for a token"
+    },
+    "apikeyRegister": {
+      "message": "Register here!",
+      "description": "Text for a link to the registration page"
+    },
+    "apikeyNode": {
+      "message": "Your preferred PhishDetect Node:",
+      "description": "Label for a text input for the url of your PhishDetect node"
+    },
+    "apikeyToken": {
+      "message": "Enter your secret token:",
+      "description": "Label for a text input for your secret token"
+    },
+    "apikeySave": {
+      "message": "Save",
+      "description": "Text for button to save api token and node settings"
+    }
+}

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -70,5 +70,21 @@
     "apikeySave": {
       "message": "Save",
       "description": "Text for button to save api token and node settings"
+    },
+    "contextMenuReportPage": {
+      "message": "Report this page as suspicious",
+      "description": "Text for context menu option to report a page"
+    },
+    "contextMenuReportLink": {
+      "message": "Report this link as suspicious",
+      "description": "Text for context menu option to report a link"
+    },
+    "contextMenuScanPage": {
+      "message": "Scan this page for phishing",
+      "description": "Text for context menu option to scan a page"
+    },
+    "contextMenuScanLink": {
+      "message": "Scan this link for phishing",
+      "description": "Text for context menu option to scan a link"
     }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -146,5 +146,21 @@
     "reportEmailConfirm": {
       "message": "Are you sure you want to report this email to your PhishDetect Node administrator?",
       "description": "Confirmation message when reporting an email"
+    },
+    "popupReported": {
+      "message": "Reported!",
+      "description": "Shown in a popup when an email is reported."
+    },
+    "popupScanning": {
+      "message": "Scanning...",
+      "description": "Shown in a popup when an email is being scanned."
+    },
+    "popupTokenRequired": {
+      "message": "We now require PhishDetect users to register a secret token.",
+      "description": "Paragraph in a popup explaining the need for a token"
+    },
+    "popupActivate": {
+      "message": "Continue here to activate your browser!",
+      "description": "Link text to register for a secret token to activate PhishDetect"
     }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -51,6 +51,22 @@
       "message": "TAKE ME AWAY",
       "description": "Text for button to abort opening a dangerous url"
     },
+    "warningPrevented": {
+      "message": "PhishDetect prevented you from visiting this page and, if you have this option enabled, alerted the administrator of your configured PhishDetect Node. For more information about this warning read the PhishDetect Help Page:",
+      "description": "Text displayed when PhishDetect prevents you from visiting a page"
+    },
+    "warningReportedNotSafe": {
+      "message": "PhishDetect reported it as not safe",
+      "description": "Text displayed when PhishDetect prevents you from visiting a page"
+    },
+    "warningWrongfullyBlocked": {
+      "message": "If you think this website was wrongfully blocked, please report the mistake here:",
+      "description": "Text displayed when PhishDetect prevents you from visiting a page"
+    },
+    "warningReportMistake": {
+      "message": "Report mistake",
+      "description": "Link text to report a wrongfully blocked page"
+    },
     "apikeyThankyou": {
       "message": "Thank you for participating to PhishDetect closed beta program!",
       "description": "Paragraph text thanking the user."
@@ -147,6 +163,10 @@
       "message": "Are you sure you want to report this email to your PhishDetect Node administrator?",
       "description": "Confirmation message when reporting an email"
     },
+    "popupReportThisPage": {
+      "message": "Report this page",
+      "description": "Button to report the page from a popup"
+    },
     "popupReported": {
       "message": "Reported!",
       "description": "Shown in a popup when an email is reported."
@@ -170,5 +190,9 @@
     "apikeySaved": {
       "message": "Saved!",
       "description": "Displayed when an apikey is saved succesfully"
+    },
+    "optionsSaved": {
+      "message": "Saved!",
+      "description": "Displayed when settings are saved succesfully"
     }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -110,5 +110,25 @@
     "webmailLinkWarning": {
       "message": "PhishDetect Warning: this link is malicious!",
       "description": "Warning text for a known malicious link"
+    },
+    "webmailDialog": {
+      "message": "How do you want to open this link?",
+      "description": "Warning text for a known malicious link"
+    },
+    "webmailDialogDirectly": {
+      "message": "Directly",
+      "description": "Button to open a link 'Directly' / 'Unsafely'"
+    },
+    "webmailDialogSafely": {
+      "message": "Safely",
+      "description": "Button to open a link 'Safely'"
+    },
+    "webmailPreview": {
+      "message": "You are about to open this link. Do you want to continue?",
+      "description": "Confirmation dialog text when opening a link"
+    },
+    "webmailPreviewContinue": {
+      "message": "Continue",
+      "description": "Button text to continue with safely previewing a link"
     }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -162,5 +162,13 @@
     "popupActivate": {
       "message": "Continue here to activate your browser!",
       "description": "Link text to register for a secret token to activate PhishDetect"
+    },
+    "apikeyErrorSecretToken": {
+      "message": "You did not provide a valid secret token.",
+      "description": "Error text when no secret token is entered in the apikey form"
+    },
+    "apikeySaved": {
+      "message": "Saved!",
+      "description": "Displayed when an apikey is saved succesfully"
     }
 }

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -154,24 +154,24 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 // Context menus.
 function loadContextMenus() {
     chrome.contextMenus.create({
-        "title": "Report this page as suspicious",
+        "title": chrome.i18n.getMessage("contextMenuReportPage"),
         "id": "report-page",
         "contexts": ["page", "frame"]
     });
     chrome.contextMenus.create({
-        "title": "Scan this page for phishing",
+        "title": chrome.i18n.getMessage("contextMenuScanPage"),
         "id": "scan-page",
         "contexts": ["page", "frame"]
     });
 
     chrome.contextMenus.create({
-        "title": "Scan this link for phishing",
+        "title": chrome.i18n.getMessage("contextMenuScanLink"),
         "id": "scan-link",
         "contexts": ["link"]
     });
 
     chrome.contextMenus.create({
-        "title": "Report this link as suspicious",
+        "title": chrome.i18n.getMessage("contextMenuReportLink"),
         "id": "report-link",
         "contexts": ["link"]
     });

--- a/src/js/gmail.js
+++ b/src/js/gmail.js
@@ -207,8 +207,8 @@ function gmailReportEmail(id) {
         }
 
         // Add button to upload email.
-        var htmlReportButton = "<span id=\"pd-report\" class=\"pd-webmail-report\"><i class=\"fas fa-fish\" style=\"color: #3490dc;margin-right: .5rem;\"></i>" + chrome.i18n.getMessage("reportEmailReport") + "</span>";
-        var htmlReportedAlready = "<span id=\"pd-reported\" style=\"cursor: pointer;\"><i class=\"fas fa-check-circle\" style=\"color: #38c172;margin-right: .5rem;\"></i>" + chrome.i18n.getMessage("reportEmailReportedAlready") + "</span>";
+        var htmlReportButton = "<span id=\"pd-report\" class=\"pd-webmail-report\"><i class=\"fas fa-fish\" style=\"color: #3490dc;margin-right: .5rem;\"></i>" + i18nHtmlSafe("reportEmailReport") + "</span>";
+        var htmlReportedAlready = "<span id=\"pd-reported\" style=\"cursor: pointer;\"><i class=\"fas fa-check-circle\" style=\"color: #38c172;margin-right: .5rem;\"></i>" + i18nHtmlSafe("reportEmailReportedAlready") + "</span>";
 
         // We delete existing buttons (this normally would happen in the case
         // of Gmail's conversation view).
@@ -222,7 +222,7 @@ function gmailReportEmail(id) {
             gmail.tools.add_toolbar_button(htmlReportButton, function() {
                 // We ask for confirmation.
                 vex.dialog.confirm({
-                    unsafeMessage: "<b>PhishDetect</b><br />" + chrome.i18n.getMessage("reportEmailConfirm"),
+                    unsafeMessage: "<b>PhishDetect</b><br />" + i18nHtmlSafe("reportEmailConfirm"),
                     callback: function(ok) {
                         if (!ok) {
                             return;

--- a/src/js/gmail.js
+++ b/src/js/gmail.js
@@ -207,8 +207,8 @@ function gmailReportEmail(id) {
         }
 
         // Add button to upload email.
-        var htmlReportButton = "<span id=\"pd-report\" class=\"pd-webmail-report\"><i class=\"fas fa-fish\" style=\"color: #3490dc;margin-right: .5rem;\"></i>Report to PhishDetect</span>";
-        var htmlReportedAlready = "<span id=\"pd-reported\" style=\"cursor: pointer;\"><i class=\"fas fa-check-circle\" style=\"color: #38c172;margin-right: .5rem;\"></i>Reported to PhishDetect</span>";
+        var htmlReportButton = "<span id=\"pd-report\" class=\"pd-webmail-report\"><i class=\"fas fa-fish\" style=\"color: #3490dc;margin-right: .5rem;\"></i>" + chrome.i18n.getMessage("reportEmailReport") + "</span>";
+        var htmlReportedAlready = "<span id=\"pd-reported\" style=\"cursor: pointer;\"><i class=\"fas fa-check-circle\" style=\"color: #38c172;margin-right: .5rem;\"></i>" + chrome.i18n.getMessage("reportEmailReportedAlready") + "</span>";
 
         // We delete existing buttons (this normally would happen in the case
         // of Gmail's conversation view).
@@ -222,7 +222,7 @@ function gmailReportEmail(id) {
             gmail.tools.add_toolbar_button(htmlReportButton, function() {
                 // We ask for confirmation.
                 vex.dialog.confirm({
-                    unsafeMessage: "<b>PhishDetect</b><br />Are you sure you want to report this email to your PhishDetect Node administrator?",
+                    unsafeMessage: "<b>PhishDetect</b><br />" + chrome.i18n.getMessage("reportEmailConfirm"),
                     callback: function(ok) {
                         if (!ok) {
                             return;

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -59,7 +59,7 @@ window.generateWebmailWarning = function generateWebmailWarning(eventType) {
 window.generateWebmailLinkWarning = function generateWebmailLinkWarning(element) {
     var span = $("<span>")
         .addClass("pd-webmail-link-warning")
-        .attr("title", "PhishDetect Warning: this link is malicious!")
+        .attr("title", chrome.i18n.getMessage("webmailLinkWarning"))
         .html(" <i class=\"fas fa-exclamation-triangle\"></i>");
 
     element.parentNode.insertBefore(span.get(0), element.nextSibling);

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -27,16 +27,24 @@ vex.defaultOptions.className = "vex-theme-default";
 // needed to show a warning message inside the supported webmails.
 window.generateWebmailWarning = function generateWebmailWarning(eventType) {
     var warningText = $("<span>")
-        .append($("<span>").css("font-size", "1.125rem").html("<i class=\"fas fa-exclamation-triangle\"></i> <b>PhishDetect</b> Warning"))
-        .append("<br />Please be cautious! ");
+        .append(
+            $("<span>")
+              .css("font-size", "1.125rem")
+              .html("<i class=\"fas fa-exclamation-triangle\"></i> <b>PhishDetect</b>")
+              .append(chrome.i18n.getMessage("webmailWarningWarning"))
+        )
+        .append("<br />")
+        .append(chrome.i18n.getMessage("webmailWarningPleaseBeCautious"));
 
     if (eventType == "email_sender" || eventType == "email_sender_domain") {
-        warningText.append("The email was sent by a known malicious address. ");
+        warningText.append(chrome.i18n.getMessage("webmailWarningSender"));
     } else if (eventType == "email_link") {
-        warningText.append("The email contains known malicious links. ");
+        warningText.append(chrome.i18n.getMessage("webmailWarningLinks"));
     }
 
-    warningText.append("For more information visit our <a style=\"text-decoration: none;\" href=\"https://phishdetect.io/help/\"><span style=\"color: #6cb2eb\"><b>Help</b></span></a> page.")
+    warningText
+      .append(chrome.i18n.getMessage("webmailWarningHelp"))
+      .append("<a style=\"text-decoration: none;\" href=\"https://phishdetect.io/help/\"><span style=\"color: #6cb2eb\"><b>phishdetect.io/help</b></span></a>")
 
     var warning = $("<div>", {id: "phishdetect-warning"})
         .addClass("pd-webmail-warning")

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -31,19 +31,19 @@ window.generateWebmailWarning = function generateWebmailWarning(eventType) {
             $("<span>")
               .css("font-size", "1.125rem")
               .html("<i class=\"fas fa-exclamation-triangle\"></i> <b>PhishDetect</b>")
-              .append(chrome.i18n.getMessage("webmailWarningWarning"))
+              .append(i18nHtmlSafe("webmailWarningWarning"))
         )
         .append("<br />")
-        .append(chrome.i18n.getMessage("webmailWarningPleaseBeCautious"));
+        .append(i18nHtmlSafe("webmailWarningPleaseBeCautious"));
 
     if (eventType == "email_sender" || eventType == "email_sender_domain") {
-        warningText.append(chrome.i18n.getMessage("webmailWarningSender"));
+        warningText.append(i18nHtmlSafe("webmailWarningSender"));
     } else if (eventType == "email_link") {
-        warningText.append(chrome.i18n.getMessage("webmailWarningLinks"));
+        warningText.append(i18nHtmlSafe("webmailWarningLinks"));
     }
 
     warningText
-      .append(chrome.i18n.getMessage("webmailWarningHelp"))
+      .append(i18nHtmlSafe("webmailWarningHelp"))
       .append("<a style=\"text-decoration: none;\" href=\"https://phishdetect.io/help/\"><span style=\"color: #6cb2eb\"><b>phishdetect.io/help</b></span></a>")
 
     var warning = $("<div>", {id: "phishdetect-warning"})
@@ -95,7 +95,7 @@ window.generateWebmailDialog = function generateWebmailDialog(anchor) {
                 "word-break": "break-all",
                 "word-break": "break-word"
             })
-            .html(`<b>PhishDetect</b><br />${chrome.i18n.getMessage("webmailDialog")}<br />` +
+            .html(`<b>PhishDetect</b><br />${i18nHtmlSafe("webmailDialog")}<br />` +
             "<span style=\"font-family: Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace; color: #2779bd;\">" + sanitizedLink + "</span>");
 
         // We spawn a dialog.
@@ -184,7 +184,7 @@ window.generateWebmailPreview = function generateWebmailPreview(anchor) {
                 "word-break": "break-all",
                 "word-break": "break-word"
             })
-            .html(`<b>PhishDetect</b><br />${chrome.i18n.getMessage("webmailPreview")}<br />` +
+            .html(`<b>PhishDetect</b><br />${i18nHtmlSafe("webmailPreview")}<br />` +
             "<span style=\"font-family: Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace; color: #2779bd;\">" + sanitizedLink + "</span>");
 
         // We spawn a dialog.

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -95,7 +95,7 @@ window.generateWebmailDialog = function generateWebmailDialog(anchor) {
                 "word-break": "break-all",
                 "word-break": "break-word"
             })
-            .html("<b>PhishDetect</b><br />How do you want to open this link?<br />" +
+            .html(`<b>PhishDetect</b><br />${chrome.i18n.getMessage("webmailDialog")}<br />` +
             "<span style=\"font-family: Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace; color: #2779bd;\">" + sanitizedLink + "</span>");
 
         // We spawn a dialog.
@@ -105,7 +105,7 @@ window.generateWebmailDialog = function generateWebmailDialog(anchor) {
             buttons: [
                 // Button to open "Safely".
                 $.extend({}, vex.dialog.buttons.YES, {
-                    text: "Safely",
+                    text: chrome.i18n.getMessage("webmailDialogSafely"),
                     className: "pd-webmail-dialog-green-button",
                     click: function($vexContent, event) {
                         this.value = "safe";
@@ -115,7 +115,7 @@ window.generateWebmailDialog = function generateWebmailDialog(anchor) {
                 }),
                 // Button to open "Directly" / "Unsafely".
                 $.extend({}, vex.dialog.buttons.YES, {
-                    text: "Directly",
+                    text: chrome.i18n.getMessage("webmailDialogDirectly"),
                     className: "pd-webmail-dialog-red-button",
                     click: function($vexContent, event) {
                         this.value = "unsafe";
@@ -184,7 +184,7 @@ window.generateWebmailPreview = function generateWebmailPreview(anchor) {
                 "word-break": "break-all",
                 "word-break": "break-word"
             })
-            .html("<b>PhishDetect</b><br />You are about to open this link. Do you want to continue?<br />" +
+            .html(`<b>PhishDetect</b><br />${chrome.i18n.getMessage("webmailPreview")}<br />` +
             "<span style=\"font-family: Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace; color: #2779bd;\">" + sanitizedLink + "</span>");
 
         // We spawn a dialog.
@@ -193,7 +193,7 @@ window.generateWebmailPreview = function generateWebmailPreview(anchor) {
             unsafeMessage: message.html(),
             buttons: [
                 $.extend({}, vex.dialog.buttons.YES, {
-                    text: "Continue",
+                    text: chrome.i18n.getMessage("webmailPreviewContinue"),
                     className: "pd-webmail-dialog-red-button",
                     click: function($vexContent, event) {
                         this.value = "continue";

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -1,0 +1,6 @@
+$('[data-resource]').each(function() {
+  var el = $(this);
+  var resourceName = el.data('resource');
+  var resourceText = chrome.i18n.getMessage(resourceName);
+  el.text(resourceText);
+});

--- a/src/js/roundcube.js
+++ b/src/js/roundcube.js
@@ -254,7 +254,8 @@ function roundcubeReportEmail(email) {
                 "cursor": "auto",
                 "padding": ".5rem"
             })
-            .html("<i class=\"fas fa-check-circle\" style=\"color: #38c172;margin-right: .5rem;\"></i>Reported to PhishDetect")
+            .html("<i class=\"fas fa-check-circle\" style=\"color: #38c172;margin-right: .5rem;\"></i>")
+            .append(chrome.i18n.getMessage("reportEmailReported"));
 
         if (isReported) {
             emailHeader.append(htmlReportedAlready);
@@ -265,10 +266,11 @@ function roundcubeReportEmail(email) {
                     "font-size": ".82rem",
                     "cursor": "pointer"
                 })
-                .html("<i class=\"fas fa-fish\" style=\"color: #3490dc;margin-right: .5rem;\"></i>Report to PhishDetect")
+                .html("<i class=\"fas fa-fish\" style=\"color: #3490dc;margin-right: .5rem;\"></i>")
+                .append(chrome.i18n.getMessage("reportEmailReport"))
                 .bind("click", function() {
                     vex.dialog.confirm({
-                        unsafeMessage: "<b>PhishDetect</b><br />Are you sure you want to report this email to your PhishDetect Node administrator?",
+                        unsafeMessage: "<b>PhishDetect</b><br />" + chrome.i18n.getMessage("reportEmailConfirm"),
                         callback: function(ok) {
                             // If user clicked cancel, end.
                             if (!ok) {

--- a/src/js/roundcube.js
+++ b/src/js/roundcube.js
@@ -255,7 +255,7 @@ function roundcubeReportEmail(email) {
                 "padding": ".5rem"
             })
             .html("<i class=\"fas fa-check-circle\" style=\"color: #38c172;margin-right: .5rem;\"></i>")
-            .append(chrome.i18n.getMessage("reportEmailReported"));
+            .append(i18nHtmlSafe("reportEmailReported"));
 
         if (isReported) {
             emailHeader.append(htmlReportedAlready);
@@ -267,10 +267,10 @@ function roundcubeReportEmail(email) {
                     "cursor": "pointer"
                 })
                 .html("<i class=\"fas fa-fish\" style=\"color: #3490dc;margin-right: .5rem;\"></i>")
-                .append(chrome.i18n.getMessage("reportEmailReport"))
+                .append(i18nHtmlSafe("reportEmailReport"))
                 .bind("click", function() {
                     vex.dialog.confirm({
-                        unsafeMessage: "<b>PhishDetect</b><br />" + chrome.i18n.getMessage("reportEmailConfirm"),
+                        unsafeMessage: "<b>PhishDetect</b><br />" + i18nHtmlSafe("reportEmailConfirm"),
                         callback: function(ok) {
                             // If user clicked cancel, end.
                             if (!ok) {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -52,3 +52,11 @@ function base64encode(str) {
         return String.fromCharCode('0x' + p1);
     }));
 }
+
+function i18nHtmlSafe(key) {
+    // Returns html-safe content for `key`
+    // Use this when embedding translation strings in html markup
+    let translation = chrome.i18n.getMessage(key);
+    let textNode = $('<div>').text(translation);
+    return textNode.html(); // return html content
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,6 +2,7 @@
     "manifest_version": 2,
 
     "name": "PhishDetect",
+    "description": "__MSG_manifestDescription__",
     "default_locale": "en",
     "icons": {
         "16": "icons/icon@16.png",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,6 +2,7 @@
     "manifest_version": 2,
 
     "name": "PhishDetect",
+    "default_locale": "en",
     "icons": {
         "16": "icons/icon@16.png",
         "34": "icons/icon@34.png",

--- a/src/ui/apikey/apikey.html
+++ b/src/ui/apikey/apikey.html
@@ -11,20 +11,28 @@
 <div id="container">
     <h2 class="text-grey-black">PhishDetect</h2>
 
-    <p class="mt-4 mb-4 leading-normal">Thank you for participating to PhishDetect closed beta program!</p>
+    <p class="mt-4 mb-4 leading-normal" data-resource="apikeyThankyou">Thank you for participating to PhishDetect closed beta program!</p>
 
-    <p class="leading-normal mb-4">In order to continue using the PhishDetect Browser Extension, you will be required to enter a valid <b>secret token</b>. You don't have one yet? <a target="_blank" id="link-register" href="#">Register here!</a></p>
+    <p class="leading-normal mb-4"><span data-resource="apikeyRegister">In order
+      to continue using the PhishDetect Browser Extension, you will be required
+      to enter a valid <b>secret token</b>. You don't have one yet?</span> <a
+      target="_blank" id="link-register" href="#" data-resource="apikeyRegister">Register here!</a></p>
 
     <div id="errors"></div>
 
     <form>
-        <label for="server">Your preferred PhishDetect Node:</label>
+        <label for="server" data-resource="apikeyNode">Your preferred PhishDetect Node:</label>
         <div class="mt-2 mb-4"><input type="text" class="block appearance-none w-full bg-white border border-grey-light px-4 py-4 rounded focus:border-blue-light" id="server" /></div>
 
-        <label for="key" id="keyLabel">Enter your secret token:</label>
+        <label for="key" id="keyLabel" data-resource="apikeyToken">Enter your secret token:</label>
         <div class="mt-2"><input type="text" class="block appearance-none w-full bg-white border border-grey-light px-4 py-4 rounded focus:border-blue-light" id="key" /></div>
 
-        <div class="mt-6"><button type="submit" class="bg-blue hover:bg-blue-light text-white py-2 px-4 border-b-4 border-blue-dark hover:text-white hover:no-underline hover:border-blue rounded cursor-pointer"><i class="fas fa-save"></i> Save</button></div>
+        <div class="mt-6">
+          <button type="submit" class="bg-blue hover:bg-blue-light text-white py-2 px-4 border-b-4 border-blue-dark hover:text-white hover:no-underline hover:border-blue rounded cursor-pointer">
+          <i class="fas fa-save"></i>
+          <span data-resource="apikeySave">Save</span>
+          </button>
+        </div>
     </form>
 </div>
 <script src="../../lib/jquery.min.js"></script>

--- a/src/ui/apikey/apikey.html
+++ b/src/ui/apikey/apikey.html
@@ -13,7 +13,7 @@
 
     <p class="mt-4 mb-4 leading-normal" data-resource="apikeyThankyou">Thank you for participating to PhishDetect closed beta program!</p>
 
-    <p class="leading-normal mb-4"><span data-resource="apikeyRegister">In order
+    <p class="leading-normal mb-4"><span data-resource="apikeyGetToken">In order
       to continue using the PhishDetect Browser Extension, you will be required
       to enter a valid <b>secret token</b>. You don't have one yet?</span> <a
       target="_blank" id="link-register" href="#" data-resource="apikeyRegister">Register here!</a></p>
@@ -38,6 +38,7 @@
 <script src="../../lib/jquery.min.js"></script>
 <script src="../../js/const.js"></script>
 <script src="../../js/config.js"></script>
+<script src="../../js/i18n.js"></script>
 <script src="apikey.js"></script>
 </body>
 </html>

--- a/src/ui/apikey/apikey.js
+++ b/src/ui/apikey/apikey.js
@@ -25,9 +25,15 @@ $("form").submit(function() {
     if (apiKey != "") {
         cfg.setApiKey(apiKey);
 
-        $("#container").html("<div class=\"text-center\"><i class=\"fas fa-check-circle text-5xl text-green\"></i><div class=\"mt-4\">Saved!</div></div>");
+        $("#container").empty().append(
+            $("<div class=\"text-center\">")
+                .append($("<i class=\"fas fa-check-circle text-5xl text-green\">"))
+                .append($("<div class=\"mt-4\">")
+                    .text(chrome.i18n.getMessage("apikeySaved"))
+                )
+        );
     } else {
-        $("#errors").html("You did not provide a valid secret token.");
+        $("#errors").text(chrome.i18n.getMessage("apikeyErrorSecretToken"));
     }
 });
 

--- a/src/ui/options/options.html
+++ b/src/ui/options/options.html
@@ -31,13 +31,20 @@
         <label for="contact" id="contactLabel" class="leading-normal" data-resource="optionsContact">If you wish, you can leave your contact details:</label>
         <div class="mt-2"><input type="text" class="block appearance-none w-full bg-white border border-grey-light px-4 py-4 rounded focus:border-blue-light" id="contact" /></div>
 
-        <div class="mt-6"><button type="submit" class="bg-blue
-            hover:bg-blue-light text-white py-2 px-4 border-b-4 border-blue-dark
-            hover:text-white hover:no-underline hover:border-blue rounded
-        cursor-pointer" data-resource="optionsSave"><i class="fas fa-save"></i>
-        Save</button> <a id="restoreDefaults" class="bg-grey hover:bg-grey-light
-    py-2 px-4 border-b-4 border-grey-dark hover:no-underline hover:border-grey
-    rounded cursor-pointer font-normal text-grey-darkest" data-resource="optionsRestore"><i class="fas fa-history"></i> Restore Defaults</a></div>
+        <div class="mt-6">
+            <button type="submit" class="bg-blue hover:bg-blue-light text-white
+                py-2 px-4 border-b-4 border-blue-dark hover:text-white
+                hover:no-underline hover:border-blue rounded cursor-pointer" >
+                <i class="fas fa-save"></i>
+                <span data-resource="optionsSave">Save</span>
+            </button>
+            <a id="restoreDefaults" class="bg-grey hover:bg-grey-light py-2 px-4
+                border-b-4 border-grey-dark hover:no-underline hover:border-grey
+                rounded cursor-pointer font-normal text-grey-darkest" >
+                <i class="fas fa-history"></i>
+                <span data-resource="optionsRestore">Restore Defaults</span>
+            </a>
+        </div>
     </form>
 </div>
 <script src="../../lib/jquery.min.js"></script>

--- a/src/ui/options/options.html
+++ b/src/ui/options/options.html
@@ -11,26 +11,37 @@
 <div id="container">
     <h2 class="text-grey-black">PhishDetect</h2>
 
-    <p class="mt-4 mb-4 leading-normal">Through this form you can decide which PhishDetect Node to connect to.</p>
+    <p class="mt-4 mb-4 leading-normal" data-resource="optionsDescription">Through this form you can decide which PhishDetect Node to connect to.</p>
 
     <form>
-        <label for="server" class="font-bold">Your preferred PhishDetect Node:</label>
+        <label for="server" class="font-bold" data-resource="optionsNode">Your preferred PhishDetect Node:</label>
         <div class="mt-2 mb-6"><input type="text" class="block appearance-none w-full bg-white border border-grey-light px-4 py-4 rounded focus:border-blue-light" id="server" /></div>
 
         <div id="keySection"><label for="key" id="keyLabel" class="font-bold">Your secret token:</label>
         <input type="text" class="block appearance-none w-full bg-white border border-grey-light px-4 py-4 rounded focus:border-blue-light" id="key" /></div>
 
-        <div class="mt-6"><input type="checkbox" id="webmails" /> <label for="webmails" class="font-bold ml-2">Enable Webmails integration</label></div>
+        <div class="mt-6"><input type="checkbox" id="webmails" /> <label
+            for="webmails" class="font-bold ml-2"
+            data-resource="optionsEnableWebmail">Enable Webmails integration</label></div>
 
-        <div class="mt-6 mb-2"><input type="checkbox" id="report" /> <label for="report" class="font-bold ml-2">Report alerts to PhishDetect Node</label></div>
+        <div class="mt-6 mb-2"><input type="checkbox" id="report" /> <label
+            for="report" class="font-bold ml-2"
+            data-resource="optionsReportAlerts">Report alerts to PhishDetect Node</label></div>
 
-        <label for="contact" id="contactLabel" class="leading-normal">If you wish, you can leave your contact details:</label>
+        <label for="contact" id="contactLabel" class="leading-normal" data-resource="optionsContact">If you wish, you can leave your contact details:</label>
         <div class="mt-2"><input type="text" class="block appearance-none w-full bg-white border border-grey-light px-4 py-4 rounded focus:border-blue-light" id="contact" /></div>
 
-        <div class="mt-6"><button type="submit" class="bg-blue hover:bg-blue-light text-white py-2 px-4 border-b-4 border-blue-dark hover:text-white hover:no-underline hover:border-blue rounded cursor-pointer"><i class="fas fa-save"></i> Save</button> <a id="restoreDefaults" class="bg-grey hover:bg-grey-light py-2 px-4 border-b-4 border-grey-dark hover:no-underline hover:border-grey rounded cursor-pointer font-normal text-grey-darkest"><i class="fas fa-history"></i> Restore Defaults</a></div>
+        <div class="mt-6"><button type="submit" class="bg-blue
+            hover:bg-blue-light text-white py-2 px-4 border-b-4 border-blue-dark
+            hover:text-white hover:no-underline hover:border-blue rounded
+        cursor-pointer" data-resource="optionsSave"><i class="fas fa-save"></i>
+        Save</button> <a id="restoreDefaults" class="bg-grey hover:bg-grey-light
+    py-2 px-4 border-b-4 border-grey-dark hover:no-underline hover:border-grey
+    rounded cursor-pointer font-normal text-grey-darkest" data-resource="optionsRestore"><i class="fas fa-history"></i> Restore Defaults</a></div>
     </form>
 </div>
 <script src="../../lib/jquery.min.js"></script>
+<script src="../../js/i18n.js"></script>
 <script src="../../js/const.js"></script>
 <script src="../../js/config.js"></script>
 <script src="options.js"></script>

--- a/src/ui/options/options.js
+++ b/src/ui/options/options.js
@@ -52,7 +52,13 @@ function saveOptions() {
     cfg.setReport($("#report").is(":checked"));
     cfg.setWebmails($("#webmails").is(":checked"));
 
-    $("#container").html("<div class=\"text-center\"><i class=\"fas fa-check-circle text-5xl text-green\"></i><div class=\"mt-4\">Saved!</div></div>");
+    $("#container").empty().append(
+        $("<div class=\"text-center\">")
+            .append($("<i class=\"fas fa-check-circle text-5xl text-green\">"))
+            .append($("<div class=\"mt-4\">")
+                .text(chrome.i18n.getMessage("optionsSaved"))
+            )
+    );
 }
 
 function restoreDefaults() {

--- a/src/ui/popup/popup.html
+++ b/src/ui/popup/popup.html
@@ -20,7 +20,7 @@
       <div class="mt-8" id="div-reportpage">
         <a class="bg-grey hover:bg-grey-light text-grey-darkest py-2 px-4 border-b-4 border-grey-dark hover:no-underline hover:border-grey rounded cursor-pointer" id="button-reportpage" title="Report this page as suspicious to your PhishDetect Node operators">
           <i class="fas fa-fish mr-2 text-blue"></i>
-          Report this page
+          <span data-resource="popupReportThisPage">Report this page</span>
         </a>
       </div>
       <div class="mt-8">

--- a/src/ui/popup/popup.html
+++ b/src/ui/popup/popup.html
@@ -10,15 +10,35 @@
 <body class="bg-grey-lightest">
 <div id="container">
     <h2 class="text-grey-black">PhishDetect</h2>
-
     <div id="content">
-	    <div class="mt-8" id="div-scanpage"><a class="bg-blue hover:bg-blue-light text-white py-2 px-4 border-b-4 border-blue-dark hover:text-white hover:no-underline hover:border-blue rounded cursor-pointer" id="button-scanpage" title="Scan this link to determine if it might be suspicious"><i class="fas fa-search mr-2"></i>Scan this page</a></div>
-	    <div class="mt-8" id="div-reportpage"><a class="bg-grey hover:bg-grey-light text-grey-darkest py-2 px-4 border-b-4 border-grey-dark hover:no-underline hover:border-grey rounded cursor-pointer" id="button-reportpage" title="Report this page as suspicious to your PhishDetect Node operators"><i class="fas fa-fish mr-2 text-blue"></i>Report this page</a></div>
-	    <div class="mt-8"><a target="_blank" href="https://phishdetect.io/help/" id="button-help"><i class="fas fa-question-circle"></i> Help</a></div>
-	    <div class="mt-4"><a href="/ui/options/options.html"><i class="fas fa-cog"></i> Settings</a></div>
-	</div>
+      <div class="mt-8" id="div-scanpage">
+        <a class="bg-blue hover:bg-blue-light text-white py-2 px-4 border-b-4 border-blue-dark hover:text-white hover:no-underline hover:border-blue rounded cursor-pointer" id="button-scanpage" title="Scan this link to determine if it might be suspicious">
+          <i class="fas fa-search mr-2"></i>
+          <span data-resource="popupScanThisPage">Scan this page!</span>
+        </a>
+      </div>
+      <div class="mt-8" id="div-reportpage">
+        <a class="bg-grey hover:bg-grey-light text-grey-darkest py-2 px-4 border-b-4 border-grey-dark hover:no-underline hover:border-grey rounded cursor-pointer" id="button-reportpage" title="Report this page as suspicious to your PhishDetect Node operators">
+          <i class="fas fa-fish mr-2 text-blue"></i>
+          Report this page
+        </a>
+      </div>
+      <div class="mt-8">
+        <a target="_blank" href="https://phishdetect.io/help/" id="button-help">
+          <i class="fas fa-question-circle"></i>
+          <span data-resource="popupHelp">Help</span>
+        </a>
+      </div>
+      <div class="mt-4">
+        <a href="/ui/options/options.html">
+          <i class="fas fa-cog"></i>
+          <span data-resource="popupSettings">Settings</span>
+        </a>
+      </div>
+    </div>
 </div>
 <script src="../../lib/jquery.min.js"></script>
+<script src="../../js/i18n.js"></script>
 <script src="../../js/const.js"></script>
 <script src="../../js/config.js"></script>
 <script src="popup.js"></script>

--- a/src/ui/popup/popup.js
+++ b/src/ui/popup/popup.js
@@ -27,7 +27,7 @@ function getTab(callback) {
 function reportPage() {
     getTab(function(tab) {
         chrome.runtime.sendMessage({method: "reportPage", url: tab.url}, function(response) {
-            $("#div-reportpage").html("Reported!");
+            $("#div-reportpage").text(chrome.i18n.getMessage("popupReported"));
         });
     });
 }
@@ -35,14 +35,22 @@ function reportPage() {
 function scanPage() {
     getTab(function(tab) {
         chrome.runtime.sendMessage({method: "scanPage", tabId: tab.id, tabUrl: tab.url}, function(response) {
-            $("#div-scanpage").html("Scanning...");
+            $("#div-scanpage").text(chrome.i18n.getMessage("popupScanning"));
         });
     });
 }
 
 document.addEventListener("DOMContentLoaded", function () {
     if (cfg.getNodeEnforceUserAuth() === true && cfg.getApiKey() == "") {
-        $("#content").html("<p class=\"mt-4 leading-normal\">We now require PhishDetect users to register a secret token. <a href=\"/ui/apikey/apikey.html\">Continue here to activate your browser!</a> <i class=\"far fa-smile text-blue\"></i></p>");
+        $("#content").empty().append(
+            $("<p class=\"mt-4 leading-normal\">")
+                .text(chrome.i18n.getMessage("popupTokenRequired") + " ")
+                .append(
+                    $("<a href=\"/ui/apikey/apikey.html\">")
+                        .text(chrome.i18n.getMessage("popupActivate"))
+                )
+                .append(" <i class=\"far fa-smile text-blue\"></i>")
+        );
         return;
     }
 

--- a/src/ui/warning/warning.html
+++ b/src/ui/warning/warning.html
@@ -9,12 +9,17 @@
 <body class="bg-black text-grey-lighter p-20">
 <div class="container mx-auto">
     <div class="text-5xl mb-4 text-center"><i class="fas fa-exclamation-triangle"></i></div>
-    <div class="text-3xl mb-4 text-center"><b>PhishDetect</b> Warning</div>
+    <div class="text-3xl mb-4 text-center"><b>PhishDetect</b> <span
+         data-resource="warningWarning">Warning</span></div>
     <div class="leading-normal text-lg">
         <p>You tried to visit <span class="font-bold font-mono" id="badURL"></span>. PhishDetect reported it as <b>not safe</b>.</p>
         <p>PhishDetect prevented you from visiting this page and, if you have this option enabled, alerted the administrator of your configured PhishDetect Node. For more information about this warning read the <a class="text-blue-light" target="_blank" href="https://phishdetect.io/help/">PhishDetect Help Page</a>.</p>
 
-        <a class="no-underline" id="takeMeAway" href="#"><div class="mt-8 py-3 px-3 bg-blue hover:bg-blue-light border-b-4 border-blue-dark hover:border-blue rounded cursor-pointer text-center text-blue-lightest no-underline text-base font-bold">TAKE ME AWAY</div></a>
+        <a class="no-underline" id="takeMeAway" href="#"><div class="mt-8 py-3
+            px-3 bg-blue hover:bg-blue-light border-b-4 border-blue-dark
+            hover:border-blue rounded cursor-pointer text-center
+        text-blue-lightest no-underline text-base font-bold"
+        data-resource="warningAway">TAKE ME AWAY</div></a>
 
         <!-- <p class="mt-12 text-sm text-red-lighter">If you want to visit this link anyway, you can do so <a id="continueAnyway" class="text-red-lighter" href="">at your own risk</a>.</p> -->
 
@@ -22,6 +27,7 @@
     </div>
 </div>
 <script src="../../lib/jquery.min.js"></script>
+<script src="../../js/i18n.js"></script>
 <script src="../../js/const.js"></script>
 <script src="../../js/config.js"></script>
 <script src="warning.js"></script>

--- a/src/ui/warning/warning.html
+++ b/src/ui/warning/warning.html
@@ -12,8 +12,21 @@
     <div class="text-3xl mb-4 text-center"><b>PhishDetect</b> <span
          data-resource="warningWarning">Warning</span></div>
     <div class="leading-normal text-lg">
-        <p>You tried to visit <span class="font-bold font-mono" id="badURL"></span>. PhishDetect reported it as <b>not safe</b>.</p>
-        <p>PhishDetect prevented you from visiting this page and, if you have this option enabled, alerted the administrator of your configured PhishDetect Node. For more information about this warning read the <a class="text-blue-light" target="_blank" href="https://phishdetect.io/help/">PhishDetect Help Page</a>.</p>
+        <p>
+            <span data-resource="warningTriedToVisit">You tried to visit</span>
+            <span class="font-bold font-mono" id="badURL"></span>.
+            <span data-resource="warningReportedNotSafe">
+              PhishDetect reported it as <b>not safe</b>
+            </span>
+        </p>
+        <p> <span data-resource="warningPrevented" >PhishDetect prevented you
+          from visiting this page and, if you have this option enabled, alerted
+          the administrator of your configured PhishDetect Node. For more
+          information about this warning read the PhishDetect Help Page:</span>
+          <a class="text-blue-light" target="_blank" href="https://phishdetect.io/help/">
+            phishdetect.io/help
+          </a>.
+        </p>
 
         <a class="no-underline" id="takeMeAway" href="#"><div class="mt-8 py-3
             px-3 bg-blue hover:bg-blue-light border-b-4 border-blue-dark
@@ -23,7 +36,13 @@
 
         <!-- <p class="mt-12 text-sm text-red-lighter">If you want to visit this link anyway, you can do so <a id="continueAnyway" class="text-red-lighter" href="">at your own risk</a>.</p> -->
 
-        <p class="mt-12">If you think this website was wrongfully blocked, please <a class="text-blue-light" id="report" href="#">report this mistake here</a>.</p>
+        <p class="mt-12">
+            <span data-resource="warningWrongfullyBlocked">
+                If you think this website was wrongfully blocked, please report
+                the mistake here:
+            </span>
+            <a data-resource="warningReportMistake" class="text-blue-light" id="report" href="#">Report mistake</a>.
+        </p>
     </div>
 </div>
 <script src="../../lib/jquery.min.js"></script>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,7 +51,6 @@ var options = {
             transform: function (content, path) {
                 // generates the manifest file using the package.json informations
                 return Buffer.from(JSON.stringify({
-                    description: process.env.npm_package_description,
                     version: process.env.npm_package_version,
                     // enable unsafe-eval in development for webpack
                     content_security_policy: (

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,6 +67,7 @@ var options = {
             {from: 'src/js',to:'js'},
             {from: 'src/lib',to:'lib'},
             {from: 'src/ui',to:'ui'},
+            {from: '_locales/',to:'_locales'},
             {from: 'node_modules/vex-js/dist/css/vex.css',to:'css'},
             {from: 'node_modules/vex-js/dist/css/vex-theme-default.css',to:'css'},
             {from: 'node_modules/tailwindcss/dist/tailwind.min.css',to:'css'},

--- a/yarn.lock
+++ b/yarn.lock
@@ -271,6 +271,11 @@ ansi-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
+ansi-styles@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
+  integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -446,6 +451,39 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
+
+babel-extract-comments@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz#0a2aedf81417ed391b85e18b4614e693a0351a21"
+  integrity sha512-qWWzi4TlddohA91bFwgt6zO/J0X+io7Qp184Fw0m2JYRSTZnJbFR8+07KmzudHCZgOiKRCrjhylwv9Xd8gfhVQ==
+  dependencies:
+    babylon "^6.18.0"
+
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+  integrity sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=
+
+babel-plugin-transform-object-rest-spread@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  integrity sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.26.0"
+
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
+
+babylon@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
+  integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -838,6 +876,17 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
+chalk@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
+  integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
+  dependencies:
+    ansi-styles "^2.2.1"
+    escape-string-regexp "^1.0.2"
+    has-ansi "^2.0.0"
+    strip-ansi "^3.0.0"
+    supports-color "^2.0.0"
+
 chalk@^2.0.1, chalk@^2.4.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -1033,6 +1082,11 @@ commander@2.17.x, commander@~2.17.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
 
+comment-regex@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/comment-regex/-/comment-regex-1.0.1.tgz#e070d2c4db33231955d0979d27c918fcb6f93565"
+  integrity sha512-IWlN//Yfby92tOIje7J18HkNmWRR7JESA/BK8W7wqY/akITpU5B0JQWnbTjCfdChSrDNb0DrdA9jfAxiiBXyiQ==
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -1171,6 +1225,11 @@ copy-webpack-plugin@^4.6.0:
     p-limit "^1.0.0"
     serialize-javascript "^1.4.0"
 
+core-js@^2.4.0:
+  version "2.6.10"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.10.tgz#8a5b8391f8cc7013da703411ce5b585706300d7f"
+  integrity sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -1291,15 +1350,15 @@ css-selector-tokenizer@^0.7.0:
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
 
-css-unit-converter@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/css-unit-converter/-/css-unit-converter-1.1.1.tgz#d9b9281adcfd8ced935bdbaba83786897f64e996"
-  integrity sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=
-
 css-what@2.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.2.tgz#c0876d9d0480927d7d4920dcd72af3595649554d"
   integrity sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ==
+
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
 
 cssesc@^0.1.0:
   version "0.1.0"
@@ -1310,11 +1369,6 @@ cssesc@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-2.0.0.tgz#3b13bd1bb1cb36e1bcb5a4dcd27f54c5dcb35703"
   integrity sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==
-
-cssesc@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
-  integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
 cyclist@~0.2.2:
   version "0.2.2"
@@ -1441,6 +1495,11 @@ define-property@^2.0.2:
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
+
+defined@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
+  integrity sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=
 
 del@^3.0.0:
   version "3.0.0"
@@ -1777,7 +1836,7 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
-escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
@@ -2174,12 +2233,12 @@ fs-extra@7.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^8.0.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
-  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+fs-extra@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+  integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
   dependencies:
-    graceful-fs "^4.2.0"
+    graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
@@ -2226,6 +2285,11 @@ function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
+gather-stream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gather-stream/-/gather-stream-1.0.0.tgz#b33994af457a8115700d410f317733cbe7a0904b"
+  integrity sha1-szmUr0V6gRVwDUEPMXczy+egkEs=
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -2407,7 +2471,7 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
-graceful-fs@^4.2.0, graceful-fs@^4.2.2:
+graceful-fs@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
   integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
@@ -2429,6 +2493,18 @@ har-validator@~5.1.0:
   dependencies:
     ajv "^6.5.5"
     har-schema "^2.0.0"
+
+has-ansi@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
+  integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
+  dependencies:
+    ansi-regex "^2.0.0"
+
+has-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+  integrity sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -3095,6 +3171,11 @@ jquery@^3.3.1, jquery@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
   integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
+
+js-base64@^2.1.9:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.1.tgz#1efa39ef2c5f7980bb1784ade4a8af2de3291121"
+  integrity sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==
 
 js-sha256@^0.9.0:
   version "0.9.0"
@@ -4006,11 +4087,6 @@ normalize-range@^0.1.2:
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
 
-normalize.css@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-8.0.1.tgz#9b98a208738b9cc2634caacbc42d131c97487bf3"
-  integrity sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==
-
 npm-audit-report@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/npm-audit-report/-/npm-audit-report-1.3.2.tgz#303bc78cd9e4c226415076a4f7e528c89fc77018"
@@ -4610,6 +4686,22 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+perfectionist@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/perfectionist/-/perfectionist-2.4.0.tgz#c147ad3714e126467f1764129ee72df861d47ea0"
+  integrity sha1-wUetNxThJkZ/F2QSnuct+GHUfqA=
+  dependencies:
+    comment-regex "^1.0.0"
+    defined "^1.0.0"
+    minimist "^1.2.0"
+    postcss "^5.0.8"
+    postcss-scss "^0.3.0"
+    postcss-value-parser "^3.3.0"
+    read-file-stdin "^0.2.0"
+    string.prototype.repeat "^0.2.0"
+    vendors "^1.0.0"
+    write-file-stdout "0.0.2"
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -4723,21 +4815,19 @@ postcss-nested@^4.1.1:
     postcss "^7.0.14"
     postcss-selector-parser "^5.0.0"
 
+postcss-scss@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-0.3.1.tgz#65c610d8e2a7ee0e62b1835b71b8870734816e4b"
+  integrity sha1-ZcYQ2OKn7g5isYNbcbiHBzSBbks=
+  dependencies:
+    postcss "^5.2.4"
+
 postcss-selector-parser@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz#249044356697b33b64f1a8f7c80922dddee7195c"
   integrity sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==
   dependencies:
     cssesc "^2.0.0"
-    indexes-of "^1.0.1"
-    uniq "^1.0.1"
-
-postcss-selector-parser@^6.0.0:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz#934cf799d016c83411859e09dcecade01286ec5c"
-  integrity sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==
-  dependencies:
-    cssesc "^3.0.0"
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
@@ -4750,6 +4840,16 @@ postcss-value-parser@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz#482282c09a42706d1fc9a069b73f44ec08391dc9"
   integrity sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==
+
+postcss@^5.0.8, postcss@^5.2.4:
+  version "5.2.18"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
+  integrity sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==
+  dependencies:
+    chalk "^1.1.3"
+    js-base64 "^2.1.9"
+    source-map "^0.5.6"
+    supports-color "^3.2.3"
 
 postcss@^6.0.9:
   version "6.0.23"
@@ -5004,6 +5104,13 @@ read-cmd-shim@^1.0.1, read-cmd-shim@^1.0.4:
   dependencies:
     graceful-fs "^4.1.2"
 
+read-file-stdin@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/read-file-stdin/-/read-file-stdin-0.2.1.tgz#25eccff3a153b6809afacb23ee15387db9e0ee61"
+  integrity sha1-JezP86FTtoCa+ssj7hU4fbng7mE=
+  dependencies:
+    gather-stream "^1.0.0"
+
 read-installed@~4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/read-installed/-/read-installed-4.0.3.tgz#ff9b8b67f187d1e4c29b9feb31f6b223acd19067"
@@ -5126,18 +5233,15 @@ recast@~0.11.12:
     private "~0.1.5"
     source-map "~0.5.0"
 
-reduce-css-calc@^2.1.6:
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/reduce-css-calc/-/reduce-css-calc-2.1.6.tgz#050fe6ee7d98a1d70775d2e93ce0b713cee394d2"
-  integrity sha512-+l5/qlQmdsbM9h6JerJ/y5vR5Ci0k93aszLNpCmbadC3nBcbRGmIBm0s9Nj59i22LvCjTGftWzdQRwdknayxhw==
-  dependencies:
-    css-unit-converter "^1.1.1"
-    postcss-value-parser "^3.3.0"
-
 regenerate@^1.2.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
+
+regenerator-runtime@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
@@ -5831,6 +5935,11 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string.prototype.repeat@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.repeat/-/string.prototype.repeat-0.2.0.tgz#aba36de08dcee6a5a337d49b2ea1da1b28fc0ecf"
+  integrity sha1-q6Nt4I3O5qWjN9SbLqHaGyj8Ds8=
+
 string_decoder@^1.0.0, string_decoder@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.2.0.tgz#fe86e738b19544afe70469243b2a1ee9240eae8d"
@@ -5869,6 +5978,14 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
+strip-comments@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/strip-comments/-/strip-comments-1.0.2.tgz#82b9c45e7f05873bee53f37168af930aa368679d"
+  integrity sha512-kL97alc47hoyIQSV165tTt9rG5dn4w1dNnBhOQ3bOU1Nc1hel09jnXANaHJ7vzHLd4Ju8kseDGzlev96pghLFw==
+  dependencies:
+    babel-extract-comments "^1.0.0"
+    babel-plugin-transform-object-rest-spread "^6.26.0"
+
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
@@ -5887,6 +6004,18 @@ style-loader@^0.23.1:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
 
+supports-color@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+  integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
+
+supports-color@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
+  integrity sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=
+  dependencies:
+    has-flag "^1.0.0"
+
 supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -5901,25 +6030,26 @@ supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
-tailwindcss@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-1.1.2.tgz#0107dc092c3edee6132b105d896b109c0f66afd6"
-  integrity sha512-mcTzZHXMipnQY9haB17baNJmBTkYYcC8ljfMdB9/97FfhKJIzlglJcyGythuQTOu7r/QIbLfZYYWZhAvaGj95A==
+tailwindcss@^0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-0.7.4.tgz#fb7926821d42eacdc12e6621a49d21f37a3ff9e9"
+  integrity sha512-+GeQjHRJ2VmeLkrNwMCbPDfm2cc5P8eoc7n+DtZfI8oQdlo5eSHqsIlPEuZOtoqQlIALsd2jAggWrUUBFGP2ow==
   dependencies:
     autoprefixer "^9.4.5"
     bytes "^3.0.0"
     chalk "^2.4.1"
-    fs-extra "^8.0.0"
-    lodash "^4.17.11"
+    css.escape "^1.5.1"
+    fs-extra "^4.0.2"
+    lodash "^4.17.5"
     node-emoji "^1.8.1"
-    normalize.css "^8.0.1"
+    perfectionist "^2.4.0"
     postcss "^7.0.11"
     postcss-functions "^3.0.0"
     postcss-js "^2.0.0"
     postcss-nested "^4.1.1"
-    postcss-selector-parser "^6.0.0"
+    postcss-selector-parser "^5.0.0"
     pretty-hrtime "^1.0.3"
-    reduce-css-calc "^2.1.6"
+    strip-comments "^1.0.2"
 
 tapable@^1.0.0, tapable@^1.1.0:
   version "1.1.1"
@@ -6329,6 +6459,11 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
+vendors@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.3.tgz#a6467781abd366217c050f8202e7e50cc9eef8c0"
+  integrity sha512-fOi47nsJP5Wqefa43kyWSg80qF+Q3XA6MUkgi7Hp1HQaKDQW4cQrK2D0P7mmbFtsV1N89am55Yru/nyEwRubcw==
+
 verror@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
@@ -6581,6 +6716,11 @@ write-file-atomic@^2.3.0:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
+
+write-file-stdout@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/write-file-stdout/-/write-file-stdout-0.0.2.tgz#c252d7c7c5b1b402897630e3453c7bfe690d9ca1"
+  integrity sha1-wlLXx8WxtAKJdjDjRTx7/mkNnKE=
 
 write-file-webpack-plugin@4.5.0:
   version "4.5.0"


### PR DESCRIPTION
Extracts all user-facing strings to /_locales/en/messages.json. This leaves the extension primed for translation on Transifex or other platform because all the strings now live in a single location. 

Such strings are used in html files, javascript files, and the extension manifest. The techniques for localizing them in each case are [officially documented](https://developer.chrome.com/extensions/i18n), but to summarize:
 
 * In manifest.json: content is referenced with `__MSG_resourcename__`, only applies to the description field in the case of this extension.
 * In js files: by calling chrome.i18n.getMessage(resourcename), possibly wrapped in an html-escaping function to ensure an in-depth defense against xss.
* In HTML files: elements are tagged with a 'data-resource' attribute identifying the appropriate string. On page load, a simple script (i18n.js) looks up and swaps in localized text content according to the browser's locale

