### PR TITLE
Use React for rendering html elements from javascript

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,1 @@
+{"presets":["env", "react"]}

--- a/package.json
+++ b/package.json
@@ -19,12 +19,18 @@
         "jquery": "^3.4.1",
         "js-sha256": "^0.9.0",
         "npm": "^6.12.1",
+        "react": "^16.11.0",
+        "react-dom": "^16.11.0",
         "tailwindcss": "^0.7.4",
         "tldts": "^3.1.2",
         "vex-dialog": "^1.1.0",
         "vex-js": "^4.1.0"
     },
     "devDependencies": {
+        "babel-core": "^6.26.3",
+        "babel-loader": "7",
+        "babel-preset-env": "^1.7.0",
+        "babel-preset-react": "^6.24.1",
         "clean-webpack-plugin": "^1.0.0",
         "copy-webpack-plugin": "^4.6.0",
         "css-loader": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     },
     "dependencies": {
         "@fortawesome/fontawesome-free": "^5.11.2",
+        "@fortawesome/fontawesome-svg-core": "^1.2.25",
+        "@fortawesome/free-solid-svg-icons": "^5.11.2",
+        "@fortawesome/react-fontawesome": "^0.1.7",
         "gmail-js": "^0.9.1",
         "jquery": "^3.4.1",
         "js-sha256": "^0.9.0",

--- a/src/components/ApiKey.js
+++ b/src/components/ApiKey.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faCheckCircle } from '@fortawesome/free-solid-svg-icons'
+export function ApiKeySaved(props) {
+    return (
+        <div className="text-center">
+            <FontAwesomeIcon icon={faCheckCircle} className="text-5x1 text-green" />
+            <div className="mt-4">
+                {chrome.i18n.getMessage("apikeySaved")}
+            </div>
+        </div>
+    );
+}
+

--- a/src/components/ConfirmationDialog.js
+++ b/src/components/ConfirmationDialog.js
@@ -1,0 +1,9 @@
+const React = require('react');
+export default function ConfirmationDialog(props) {
+    return (
+        <span>
+          <b>PhishDetect</b><br />
+          {chrome.i18n.getMessage("reportEmailConfirm")}
+        </span>
+    );
+}

--- a/src/components/Options.js
+++ b/src/components/Options.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faCheckCircle } from '@fortawesome/free-solid-svg-icons'
+export function OptionsSaved(props) {
+    return (
+        <div className="text-center">
+            <FontAwesomeIcon icon={faCheckCircle} className="text-5x1 text-green" />
+            <div className="mt-4">
+                {chrome.i18n.getMessage("optionsSaved")}
+            </div>
+        </div>
+    );
+}
+

--- a/src/components/Popup.js
+++ b/src/components/Popup.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faSmile } from '@fortawesome/free-solid-svg-icons'
+export function PopupActivate(props) {
+    return (
+        <div>
+            <p className="mt-4 leading-normal">
+                {chrome.i18n.getMessage("popupTokenRequired") + " "}
+                <a href="/ui/apikey/apikey.html">
+                    {chrome.i18n.getMessage("popupActivate")}
+                </a> <FontAwesomeIcon icon={faSmile} className="text-blue" />
+            </p>
+        </div>
+    );
+}
+

--- a/src/components/ReportEmailButton.js
+++ b/src/components/ReportEmailButton.js
@@ -1,0 +1,27 @@
+const React = require('react');
+function WebmailButton(props) {
+    let { className, icon, message } = props;
+
+    return (
+        <span id="pd-report" className={`pd-webmail-button ${className}`}>
+            <i className={`pd-webmail-button-icon fas ${icon}`}> </i>
+            {message}
+        </span>
+    );
+}
+
+export default class ReportEmailButton extends React.Component {
+    render() {
+        if (this.props.reported) {
+            return (
+                <WebmailButton className='pd-webmail-reported' icon='fa-check-circle'
+                    message={chrome.i18n.getMessage("reportEmailReportedAlready")} />
+            );
+        } else {
+            return (
+                <WebmailButton className='pd-webmail-report' icon='fa-fish'
+                    message={chrome.i18n.getMessage("reportEmailReport")} />
+            );
+        }
+    }
+}

--- a/src/components/ReportEmailButton.js
+++ b/src/components/ReportEmailButton.js
@@ -1,11 +1,14 @@
 const React = require('react');
 const vex = require('vex-js');
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faFish, faCheckCircle } from '@fortawesome/free-solid-svg-icons'
+
 function WebmailButton(props) {
     let { className, icon, message, onClick } = props;
 
     return (
         <span id="pd-report" className={`pd-webmail-button ${className}`} onClick={onClick}>
-            <i className={`pd-webmail-button-icon fas ${icon}`}> </i>
+            <FontAwesomeIcon icon={icon} className="pd-webmail-button-icon" />
             {message}
         </span>
     );
@@ -54,12 +57,12 @@ export default class ReportEmailButton extends React.Component {
     render() {
         if (this.state.reported) {
             return (
-                <WebmailButton className='pd-webmail-reported' icon='fa-check-circle'
+                <WebmailButton className='pd-webmail-reported' icon={faCheckCircle}
                     message={chrome.i18n.getMessage("reportEmailReportedAlready")} />
             );
         } else {
             return (
-                <WebmailButton className='pd-webmail-report' icon='fa-fish'
+                <WebmailButton className='pd-webmail-report' icon={faFish}
                     message={chrome.i18n.getMessage("reportEmailReport")}
                     onClick={this.onClick.bind(this)} />
             );

--- a/src/components/ReportEmailButton.js
+++ b/src/components/ReportEmailButton.js
@@ -1,9 +1,10 @@
 const React = require('react');
+const vex = require('vex-js');
 function WebmailButton(props) {
-    let { className, icon, message } = props;
+    let { className, icon, message, onClick } = props;
 
     return (
-        <span id="pd-report" className={`pd-webmail-button ${className}`}>
+        <span id="pd-report" className={`pd-webmail-button ${className}`} onClick={onClick}>
             <i className={`pd-webmail-button-icon fas ${icon}`}> </i>
             {message}
         </span>
@@ -11,8 +12,47 @@ function WebmailButton(props) {
 }
 
 export default class ReportEmailButton extends React.Component {
+    constructor(props) {
+        super(props);
+        let { reported, uid } = props;
+        this.state = { reported, uid };
+    }
+
+    onClick() {
+        if (this.state.reported) {
+            return;
+        }
+        vex.dialog.confirm({
+            unsafeMessage: generateConfirmationDialog(),
+            callback: this.onConfirm.bind(this)
+        });
+    }
+
+    onConfirm(ok) {
+        // If user clicked cancel, end.
+        if (!ok) {
+            return;
+        }
+
+        var promise = this.props.getEmailPromise();
+        if (promise) {
+            promise.then(this.onEmailPromiseResolved.bind(this));
+        }
+    }
+
+    onEmailPromiseResolved(result) {
+        this.setState({reported: true});
+
+        chrome.runtime.sendMessage({
+            method: "sendRaw",
+            rawType: "email",
+            rawContent: result,
+            identifier: this.state.uid,
+        });
+    }
+
     render() {
-        if (this.props.reported) {
+        if (this.state.reported) {
             return (
                 <WebmailButton className='pd-webmail-reported' icon='fa-check-circle'
                     message={chrome.i18n.getMessage("reportEmailReportedAlready")} />
@@ -20,7 +60,8 @@ export default class ReportEmailButton extends React.Component {
         } else {
             return (
                 <WebmailButton className='pd-webmail-report' icon='fa-fish'
-                    message={chrome.i18n.getMessage("reportEmailReport")} />
+                    message={chrome.i18n.getMessage("reportEmailReport")}
+                    onClick={this.onClick.bind(this)} />
             );
         }
     }

--- a/src/components/WebmailLinkDialog.js
+++ b/src/components/WebmailLinkDialog.js
@@ -1,0 +1,10 @@
+const React = require('react');
+export default function WebmailLinkDialog(props) {
+    return (
+        <span className="pd-webmail-dialog">
+            <b>PhishDetect</b><br />
+            {props.content} <br />
+            <span className="pd-webmail-dialog-url"> {props.href} </span>
+        </span>
+    );
+}

--- a/src/components/WebmailLinkWarning.js
+++ b/src/components/WebmailLinkWarning.js
@@ -1,10 +1,12 @@
 const React = require('react');
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
 export default function WebmailLinkWarning(props) {
     return (
         <span className="pd-webmail-link-warning"
               title={chrome.i18n.getMessage("webmailLinkWarning")}>
             {' '}
-            <i className="fas fa-exclamation-triangle"></i>
+            <FontAwesomeIcon icon={faExclamationTriangle} />
         </span>
     );
 }

--- a/src/components/WebmailLinkWarning.js
+++ b/src/components/WebmailLinkWarning.js
@@ -1,0 +1,10 @@
+const React = require('react');
+export default function WebmailLinkWarning(props) {
+    return (
+        <span className="pd-webmail-link-warning"
+              title={chrome.i18n.getMessage("webmailLinkWarning")}>
+            {' '}
+            <i className="fas fa-exclamation-triangle"></i>
+        </span>
+    );
+}

--- a/src/components/WebmailWarning.js
+++ b/src/components/WebmailWarning.js
@@ -1,4 +1,6 @@
 const React = require('react');
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
 export default class WebmailWarning extends React.Component {
     getWarningText(eventType) {
         switch(eventType) {
@@ -15,7 +17,7 @@ export default class WebmailWarning extends React.Component {
             <div id="phishdetect-warning" className="pd-webmail-warning"
                  style={ {paddingTop: '1rem'} }>
                 <span style={ {fontSize: '1.125rem'} }>
-                    <i className="fas fa-exclamation-triangle"></i> <b>PhishDetect</b>
+                    <FontAwesomeIcon icon={faExclamationTriangle} /> <b>PhishDetect</b>
                     {' '}
                     {chrome.i18n.getMessage("webmailWarningWarning")}
                 </span>

--- a/src/components/WebmailWarning.js
+++ b/src/components/WebmailWarning.js
@@ -1,0 +1,37 @@
+const React = require('react');
+export default class WebmailWarning extends React.Component {
+    getWarningText(eventType) {
+        switch(eventType) {
+          case "email_sender":
+          case "email_sender_domain":
+              return chrome.i18n.getMessage("webmailWarningSender");
+          case "email_link":
+              return chrome.i18n.getMessage("webmailWarningLinks");
+        }
+    }
+
+    render() {
+        return (
+            <div id="phishdetect-warning" className="pd-webmail-warning"
+                 style={ {paddingTop: '1rem'} }>
+                <span style={ {fontSize: '1.125rem'} }>
+                    <i className="fas fa-exclamation-triangle"></i> <b>PhishDetect</b>
+                    {' '}
+                    {chrome.i18n.getMessage("webmailWarningWarning")}
+                </span>
+                <br />
+                {chrome.i18n.getMessage("webmailWarningPleaseBeCautious")}
+                {' '}
+                {this.getWarningText(this.props.eventType)}
+                {' '}
+                {chrome.i18n.getMessage("webmailWarningHelp")}
+                {' '}
+                <a style={{textDecoration: 'none'}} href="https://phishdetect.io/help/">
+                    <span style={{color: '#6cb2eb'}}>
+                        <b>phishdetect.io/help</b>
+                    </span>
+                </a>
+            </div>
+        );
+    }
+}

--- a/src/css/phishdetect-webmails.css
+++ b/src/css/phishdetect-webmails.css
@@ -22,6 +22,38 @@
 .pd-webmail-report:hover {
     background-color: #f1f5f8;
 }
+.pd-webmail-button-icon {
+    margin-right: .5rem;
+}
+.pd-webmail-button .fa-fish {
+    color: #3490dc;
+}
+.pd-webmail-button .fa-check-circle {
+    color: #38c172;
+}
 .pd-webmail-link-warning {
     color: #e3342f;
+}
+.pd-webmail-button.roundcube {
+    display: block;
+    font-size: .82rem;
+}
+.pd-webmail-reported {
+    cursor: auto;
+}
+.pd-webmail-report.pd-webmail-button.roundcube {
+    cursor: pointer;
+    padding: .5rem;
+}
+
+.pd-webmail-dialog {
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    -ms-word-break: break-all;
+    word-break: break-all;
+    word-break: break-word;
+}
+.pd-webmail-dialog-url {
+    font-family: Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace;
+    color: #2779bd;
 }

--- a/src/css/phishdetect-webmails.css
+++ b/src/css/phishdetect-webmails.css
@@ -34,14 +34,14 @@
 .pd-webmail-link-warning {
     color: #e3342f;
 }
-.pd-webmail-button.roundcube {
+.roundcube .pd-webmail-button {
     display: block;
     font-size: .82rem;
 }
 .pd-webmail-reported {
     cursor: auto;
 }
-.pd-webmail-report.pd-webmail-button.roundcube {
+.roundcube .pd-webmail-report.pd-webmail-button {
     cursor: pointer;
     padding: .5rem;
 }

--- a/src/js/checkEmail.js
+++ b/src/js/checkEmail.js
@@ -1,0 +1,139 @@
+// checkEmail will try to determine if any element in the email matches a
+// known indicator. In order to do so it will try to:
+//   1. Check the full email sender among the list of blocklisted email addresses.
+//   2. Check the domain of the email sender among the list of blocklisted domains.
+//   3. Check all the anchors in the email among the list of blocklisted domains.
+// If it matches anything, it will display a warning, highlight any bad link,
+// and send an alert through the "sendEvent" message to the background script.
+export default function checkEmail(fromEmail, emailBody, uid) {
+
+    console.log("Checking email sender:", fromEmail);
+
+    var fromEmailHash = sha256(fromEmail);
+    var fromEmailDomain = "";
+    var fromEmailDomainHash = "";
+    var fromEmailTopDomain = "";
+    var fromEmailTopDomainHash = "";
+
+    // We extract the domain from the email address.
+    var parts = fromEmail.split('@');
+    if (parts.length === 2) {
+        fromEmailDomain = getDomainFromURL(parts[1]);
+        fromEmailDomainHash = sha256(fromEmailDomain);
+        fromEmailTopDomain = getTopDomainFromURL(parts[1]);
+        fromEmailTopDomainHash = sha256(fromEmailTopDomain);
+    }
+
+    // First we get the list of indicators.
+    chrome.runtime.sendMessage({method: "getIndicators"}, function(response) {
+        // Fail if we don't have any indicators.
+        if (response == "") {
+            return false;
+        }
+        var indicators = response;
+
+        if (indicators === undefined) {
+            return false;
+        }
+
+        // Email status.
+        var isEmailBad = false;
+        var eventType = "";
+        var eventMatch = "";
+        var eventIndicator = "";
+
+        // We check for email addresses, if we have any indicators to check.
+        if (indicators.emails !== null) {
+            var itemsToCheck = [fromEmailHash,];
+            var matchedIndicator = checkForIndicators(itemsToCheck, indicators.emails);
+            if (matchedIndicator !== null) {
+                console.log("Detected bad email sender with indicator:", matchedIndicator);
+
+                // Mark email as bad.
+                isEmailBad = true;
+                eventType = "email_sender";
+                eventMatch = fromEmail;
+                eventIndicator = matchedIndicator;
+            }
+        }
+
+        // TODO: Need to review the performance of this.
+        // We check for domains, if we have any indicators to check.
+        if (indicators.domains !== null) {
+            // First we check the domain of the email sender.
+            var itemsToCheck = [fromEmailDomainHash, fromEmailTopDomainHash];
+            var matchedIndicator = checkForIndicators(itemsToCheck, indicators.domains);
+            if (matchedIndicator !== null) {
+                console.log("Detected email sender domain with indicator:", matchedIndicator);
+
+                // Mark whole email as bad.
+                // TODO: this is ugly.
+                isEmailBad = true;
+                eventType = "email_sender_domain";
+                eventMatch = fromEmail;
+                eventIndicator = matchedIndicator;
+            }
+
+            // Now we check for links contained in the emails body.
+            // We extract all links from the body of the email.
+            var anchors = $(emailBody).find("a");
+
+            // TODO: Might want to reverse these loops for performance reasons.
+            for (var i=0; i<anchors.length; i++) {
+                // Lowercase the link.
+                var href = anchors[i].href.toLowerCase();
+
+                // Only check for HTTP links.
+                // NOTE: also scanning for mailto: links (currently experimental).
+                if (href.indexOf("http://") != 0 && href.indexOf("https://") != 0 && href.indexOf("mailto:") != 0) {
+                    continue;
+                }
+
+                console.log("Checking link:", href);
+
+                var hrefDomain = getDomainFromURL(href);
+                var hrefDomainHash = sha256(hrefDomain);
+                var hrefTopDomain = getTopDomainFromURL(href);
+                var hrefTopDomainHash = sha256(hrefTopDomain);
+
+                // We loop through the list of hashed bad domains.
+                var elementsToCheck = [hrefDomainHash, hrefTopDomainHash];
+                var matchedIndicator = checkForIndicators(elementsToCheck, indicators.domains);
+                if (matchedIndicator !== null) {
+                    console.log("Detected bad link with indicator:", matchedIndicator);
+
+                    // We add a warning sign to the link.
+                    generateWebmailLinkWarning(anchors[i]);
+
+                    // Mark whole email as bad.
+                    // TODO: this is ugly.
+                    isEmailBad = true;
+                    eventType = "email_link";
+                    eventMatch = href;
+                    eventIndicator = matchedIndicator;
+
+                    break;
+                }
+            }
+        }
+
+        // TODO: this is ugly.
+        // If there is any malicious element we proceed with notifications.
+        if (isEmailBad === true) {
+            // First we send an "event" to the PhishDetect Node through the "sendEvent"
+            // message to the background script. This will proceed only if the
+            // appropriate settings option is enabled.
+            chrome.runtime.sendMessage({
+                method: "sendEvent",
+                eventType: eventType,
+                match: eventMatch,
+                indicator: eventIndicator,
+                identifier: uid,
+            });
+
+            // Then we display a warning to the user inside the Gmail web interface.
+            var warning = generateWebmailWarning(eventType);
+            emailBody.prepend(warning);
+        }
+    });
+}

--- a/src/js/gmail.js
+++ b/src/js/gmail.js
@@ -22,152 +22,19 @@ const GmailFactory = require("gmail-js");
 const gmail = new GmailFactory.Gmail($);
 window.gmail = gmail;
 
-// gmailCheckEmail will try to determine if any element in the email matches a
-// known indicator. In order to do so it will try to:
-//   1. Check the full email sender among the list of blocklisted email addresses.
-//   2. Check the domain of the email sender among the list of blocklisted domains.
-//   3. Check all the anchors in the email among the list of blocklisted domains.
-// If it matches anything, it will display a warning, highlight any bad link,
-// and send an alert through the "sendEvent" message to the background script.
-function gmailCheckEmail(id) {
-    console.log("Checking email", id)
+import checkEmail from './checkEmail.js'
+
+function gmailCheckEmail(uid) {
+    console.log("Checking email", uid)
 
     // Extract the email DOM.
-    var email = new gmail.dom.email(id);
+    var email = new gmail.dom.email(uid);
+    var emailBody = email.dom("body");
     // Extract from field and prepare hashes.
     var from = email.from();
     var fromEmail = from["email"].toLowerCase();
-    var fromEmailHash = sha256(fromEmail);
-    var fromEmailDomain = "";
-    var fromEmailDomainHash = "";
-    var fromEmailTopDomain = "";
-    var fromEmailTopDomainHash = "";
 
-    // We extract the domain from the email address.
-    var parts = fromEmail.split('@');
-    if (parts.length === 2) {
-        fromEmailDomain = getDomainFromURL(parts[1]);
-        fromEmailDomainHash = sha256(fromEmailDomain);
-        fromEmailTopDomain = getTopDomainFromURL(parts[1]);
-        fromEmailTopDomainHash = sha256(fromEmailTopDomain);
-    }
-
-    console.log("Checking email sender:", fromEmail);
-
-    // First we get the list of indicators.
-    chrome.runtime.sendMessage({method: "getIndicators"}, function(response) {
-        // Fail if we don't have any indicators.
-        if (response == "") {
-            return false
-        }
-        var indicators = response;
-
-        if (indicators === undefined) {
-            return false
-        }
-
-        // Email status.
-        var isEmailBad = false;
-        var eventType = "";
-        var eventMatch = "";
-        var eventIndicator = "";
-
-        // We check for email addresses, if we have any indicators to check.
-        if (indicators.emails !== null) {
-            var itemsToCheck = [fromEmailHash,];
-            var matchedIndicator = checkForIndicators(itemsToCheck, indicators.emails);
-            if (matchedIndicator !== null) {
-                console.log("Detected bad email sender with indicator:", matchedIndicator);
-
-                // Mark email as bad.
-                isEmailBad = true;
-                eventType = "email_sender";
-                eventMatch = fromEmail;
-                eventIndicator = matchedIndicator;
-            }
-        }
-
-        // TODO: Need to review the performance of this.
-        // We check for domains, if we have any indicators to check.
-        if (indicators.domains !== null) {
-            // First we check the domain of the email sender.
-            var itemsToCheck = [fromEmailDomainHash, fromEmailTopDomainHash];
-            var matchedIndicator = checkForIndicators(itemsToCheck, indicators.domains);
-            if (matchedIndicator !== null) {
-                console.log("Detected email sender domain with indicator:", matchedIndicator);
-
-                // Mark whole email as bad.
-                // TODO: this is ugly.
-                isEmailBad = true;
-                eventType = "email_sender_domain";
-                eventMatch = fromEmail;
-                eventIndicator = matchedIndicator;
-            }
-
-            // Now we check for links contained in the emails body.
-            // We extract all links from the body of the email.
-            var emailBody = email.dom("body");
-            var anchors = $(emailBody).find("a");
-
-            // TODO: Might want to reverse these loops for performance reasons.
-            for (var i=0; i<anchors.length; i++) {
-                // Lowercase the link.
-                var href = anchors[i].href.toLowerCase();
-
-                // Only check for HTTP links.
-                // NOTE: also scanning for mailto: links (currently experimental).
-                if (href.indexOf("http://") != 0 && href.indexOf("https://") != 0 && href.indexOf("mailto:") != 0) {
-                    continue;
-                }
-
-                console.log("Checking link:", href);
-
-                var hrefDomain = getDomainFromURL(href);
-                var hrefDomainHash = sha256(hrefDomain);
-                var hrefTopDomain = getTopDomainFromURL(href);
-                var hrefTopDomainHash = sha256(hrefTopDomain);
-
-                // We loop through the list of hashed bad domains.
-                var elementsToCheck = [hrefDomainHash, hrefTopDomainHash];
-                var matchedIndicator = checkForIndicators(elementsToCheck, indicators.domains);
-                if (matchedIndicator !== null) {
-                    console.log("Detected bad link with indicator:", matchedIndicator);
-
-                    // We add a warning sign to the link.
-                    generateWebmailLinkWarning(anchors[i]);
-
-                    // Mark whole email as bad.
-                    // TODO: this is ugly.
-                    isEmailBad = true;
-                    eventType = "email_link";
-                    eventMatch = href;
-                    eventIndicator = matchedIndicator;
-
-                    break;
-                }
-            }
-        }
-
-        // TODO: this is ugly.
-        // If there is any malicious element we proceed with notifications.
-        if (isEmailBad === true) {
-            // First we send an "event" to the PhishDetect Node through the "sendEvent"
-            // message to the background script. This will proceed only if the
-            // appropriate settings option is enabled.
-            chrome.runtime.sendMessage({
-                method: "sendEvent",
-                eventType: eventType,
-                match: eventMatch,
-                indicator: eventIndicator,
-                identifier: id,
-            });
-
-            // Then we display a warning to the user inside the Gmail web interface.
-            var emailBody = email.dom("body");
-            var warning = generateWebmailWarning(eventType);
-            emailBody.prepend(warning);
-        }
-    });
+    return checkEmail(fromEmail, emailBody, uid);
 }
 
 // gmailModifyEmail will modify the email body and rewrite links to open our

--- a/src/js/gmail.js
+++ b/src/js/gmail.js
@@ -207,8 +207,8 @@ function gmailReportEmail(id) {
         }
 
         // Add button to upload email.
-        var htmlReportButton = "<span id=\"pd-report\" class=\"pd-webmail-report\"><i class=\"fas fa-fish\" style=\"color: #3490dc;margin-right: .5rem;\"></i>" + i18nHtmlSafe("reportEmailReport") + "</span>";
-        var htmlReportedAlready = "<span id=\"pd-reported\" style=\"cursor: pointer;\"><i class=\"fas fa-check-circle\" style=\"color: #38c172;margin-right: .5rem;\"></i>" + i18nHtmlSafe("reportEmailReportedAlready") + "</span>";
+        var htmlReportButton = generateReportEmailButton();
+        var htmlReportedAlready = generateReportedAlreadyButton();
 
         // We delete existing buttons (this normally would happen in the case
         // of Gmail's conversation view).
@@ -222,7 +222,7 @@ function gmailReportEmail(id) {
             gmail.tools.add_toolbar_button(htmlReportButton, function() {
                 // We ask for confirmation.
                 vex.dialog.confirm({
-                    unsafeMessage: "<b>PhishDetect</b><br />" + i18nHtmlSafe("reportEmailConfirm"),
+                    unsafeMessage: generateConfirmationDialog(),
                     callback: function(ok) {
                         if (!ok) {
                             return;
@@ -231,7 +231,7 @@ function gmailReportEmail(id) {
                         var promise = gmail.get.email_source_promise(id);
                         if (promise) {
                             promise.then(function(result) {
-                                $("#pd-report").html(htmlReportedAlready);
+                                $("#pd-report").replaceWith(htmlReportedAlready);
 
                                 chrome.runtime.sendMessage({
                                     method: "sendRaw",

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -24,6 +24,7 @@ vex.registerPlugin(require("vex-dialog"));
 vex.defaultOptions.className = "vex-theme-default";
 
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { renderToString } from 'react-dom/server';
 import WebmailWarning from "../components/WebmailWarning";
 import WebmailLinkWarning from "../components/WebmailLinkWarning";
@@ -31,23 +32,30 @@ import WebmailLinkDialog from '../components/WebmailLinkDialog';
 import ReportEmailButton from '../components/ReportEmailButton';
 import ConfirmationDialog from '../components/ConfirmationDialog';
 
-function render(element, options) {
-    return renderToString(React.createElement(element, options));
+// A helper to render HTML strings from React components
+function renderHTML(component, options) {
+    return renderToString(React.createElement(component, options));
+}
+// A helper to render a React component directly into a DOM element
+// This includes attaching any behaviors defined by the component
+function renderDOM(component, options, element) {
+    ReactDOM.render(React.createElement(component, options), element);
 }
 
 // generateWebmailWarning is a helper function used to generate the HTML
 // needed to show a warning message inside the supported webmails.
 window.generateWebmailWarning = function generateWebmailWarning(eventType) {
-    return render(WebmailWarning, {eventType: eventType});
+    return renderHTML(WebmailWarning, {eventType: eventType});
 }
-window.generateReportEmailButton = function() {
-    return render(ReportEmailButton, {reported: false});
-}
-window.generateReportedAlreadyButton = function() {
-    return render(ReportEmailButton, {reported: true});
+// Renders a button into an existing DOM element and attachs a click handler
+// element: the container DOM element
+// getEmailPromise: a function that returns a promise resolving to an email
+// uid: the unique identifier for the email
+window.generateReportEmailButton = function(element, options) {
+    return renderDOM(ReportEmailButton, options, element);
 }
 window.generateConfirmationDialog = function() {
-    return render(ConfirmationDialog);
+    return renderHTML(ConfirmationDialog);
 }
 
 // generateWebmailLinkWarning appends a red warning sign to an HTML element
@@ -77,7 +85,7 @@ window.generateWebmailDialog = function generateWebmailDialog(anchor) {
         event.preventDefault();
 
         // We safely render the link and preview it in the dialog.
-        var message = render(WebmailLinkDialog, {
+        var message = renderHTML(WebmailLinkDialog, {
             content: chrome.i18n.getMessage("webmailDialog"),
             href: href
         });
@@ -159,7 +167,7 @@ window.generateWebmailPreview = function generateWebmailPreview(anchor) {
         // var unsafeUrl = event.srcElement.getAttribute("href");
         var unsafeUrl = href;
         // We sanitize the link and preview it in the dialog.
-        var message = render(WebmailLinkDialog, {
+        var message = renderHTML(WebmailLinkDialog, {
             content: chrome.i18n.getMessage("webmailPreview"),
             href: href
         });

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -23,35 +23,18 @@ window.vex = vex;
 vex.registerPlugin(require("vex-dialog"));
 vex.defaultOptions.className = "vex-theme-default";
 
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import WebmailWarning from "../components/WebmailWarning";
+
+function render(element, options) {
+    return renderToString(React.createElement(element, options));
+}
+
 // generateWebmailWarning is a helper function used to generate the HTML
 // needed to show a warning message inside the supported webmails.
 window.generateWebmailWarning = function generateWebmailWarning(eventType) {
-    var warningText = $("<span>")
-        .append(
-            $("<span>")
-              .css("font-size", "1.125rem")
-              .html("<i class=\"fas fa-exclamation-triangle\"></i> <b>PhishDetect</b>")
-              .append(i18nHtmlSafe("webmailWarningWarning"))
-        )
-        .append("<br />")
-        .append(i18nHtmlSafe("webmailWarningPleaseBeCautious"));
-
-    if (eventType == "email_sender" || eventType == "email_sender_domain") {
-        warningText.append(i18nHtmlSafe("webmailWarningSender"));
-    } else if (eventType == "email_link") {
-        warningText.append(i18nHtmlSafe("webmailWarningLinks"));
-    }
-
-    warningText
-      .append(i18nHtmlSafe("webmailWarningHelp"))
-      .append("<a style=\"text-decoration: none;\" href=\"https://phishdetect.io/help/\"><span style=\"color: #6cb2eb\"><b>phishdetect.io/help</b></span></a>")
-
-    var warning = $("<div>", {id: "phishdetect-warning"})
-        .addClass("pd-webmail-warning")
-        .css("padding-top", "1rem")
-        .append(warningText);
-
-    return warning;
+    return render(WebmailWarning, {eventType: eventType});
 }
 
 // generateWebmailLinkWarning appends a red warning sign to an HTML element

--- a/src/js/roundcube.js
+++ b/src/js/roundcube.js
@@ -248,29 +248,17 @@ function roundcubeReportEmail(email) {
             return;
         }
 
-        var htmlReportedAlready = $("<div>")
-            .css({
-                "font-size": ".82rem",
-                "cursor": "auto",
-                "padding": ".5rem"
-            })
-            .html("<i class=\"fas fa-check-circle\" style=\"color: #38c172;margin-right: .5rem;\"></i>")
-            .append(i18nHtmlSafe("reportEmailReported"));
+        var htmlReportedAlready = $.parseHTML(generateReportedAlreadyButton())
+            .addClass('roundcube');
 
         if (isReported) {
             emailHeader.append(htmlReportedAlready);
         } else {
-            var htmlReportButton = $("<div>", {id: "pd-report"})
-                .addClass("pd-webmail-report")
-                .css({
-                    "font-size": ".82rem",
-                    "cursor": "pointer"
-                })
-                .html("<i class=\"fas fa-fish\" style=\"color: #3490dc;margin-right: .5rem;\"></i>")
-                .append(i18nHtmlSafe("reportEmailReport"))
+            var button = $.parseHTML(generateReportEmailButton())
+                .addClass('roundcube')
                 .bind("click", function() {
                     vex.dialog.confirm({
-                        unsafeMessage: "<b>PhishDetect</b><br />" + i18nHtmlSafe("reportEmailConfirm"),
+                        unsafeMessage: generateConfirmationDialog(),
                         callback: function(ok) {
                             // If user clicked cancel, end.
                             if (!ok) {
@@ -281,9 +269,8 @@ function roundcubeReportEmail(email) {
                             if (promise) {
                                 promise.then(function(result) {
                                     $("#pd-report")
-                                        .removeClass("pd-webmail-report")
-                                        .html(htmlReportedAlready)
-                                        .unbind("click");
+                                        .unbind("click")
+                                        .replaceWith(htmlReportedAlready)
 
                                     chrome.runtime.sendMessage({
                                         method: "sendRaw",
@@ -297,7 +284,7 @@ function roundcubeReportEmail(email) {
                     });
                 });
 
-            emailHeader.append(htmlReportButton);
+            emailHeader.append(button);
         }
     });
 }

--- a/src/js/roundcube.js
+++ b/src/js/roundcube.js
@@ -129,44 +129,13 @@ function roundcubeReportEmail(email) {
             return;
         }
 
-        var htmlReportedAlready = $.parseHTML(generateReportedAlreadyButton())
-            .addClass('roundcube');
-
-        if (isReported) {
-            emailHeader.append(htmlReportedAlready);
-        } else {
-            var button = $.parseHTML(generateReportEmailButton())
-                .addClass('roundcube')
-                .bind("click", function() {
-                    vex.dialog.confirm({
-                        unsafeMessage: generateConfirmationDialog(),
-                        callback: function(ok) {
-                            // If user clicked cancel, end.
-                            if (!ok) {
-                                return;
-                            }
-
-                            var promise = roundcubeGetEmailSource();
-                            if (promise) {
-                                promise.then(function(result) {
-                                    $("#pd-report")
-                                        .unbind("click")
-                                        .replaceWith(htmlReportedAlready)
-
-                                    chrome.runtime.sendMessage({
-                                        method: "sendRaw",
-                                        rawType: "email",
-                                        rawContent: result,
-                                        identifier: uid,
-                                    });
-                                });
-                            }
-                        }
-                    });
-                });
-
-            emailHeader.append(button);
-        }
+        var element = $('<div>').addClass('roundcube').get(0);
+        generateReportEmailButton(element, {
+            uid: uid,
+            reported: isReported,
+            getEmailPromise: roundcubeGetEmailSource
+        });
+        emailHeader.append(element);
     });
 }
 

--- a/src/js/roundcube.js
+++ b/src/js/roundcube.js
@@ -151,3 +151,4 @@ function roundcube() {
     roundcubeCheckEmail(email);
     roundcubeModifyEmail(email);
 }
+window.roundcube = roundcube;

--- a/src/js/roundcube.js
+++ b/src/js/roundcube.js
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU General Public License
 // along with PhishDetect.  If not, see <https://www.gnu.org/licenses/>.
 
+import checkEmail from './checkEmail.js'
+
 function roundcubeGetOpenEmailUID() {
     var url = new URL(location.href);
     return url.searchParams.get("_uid");
@@ -84,129 +86,8 @@ function roundcubeCheckEmail(email) {
 
     // Get email sender.
     var fromEmail = from.attr("href").toLowerCase().replace("mailto:", "");
-    console.log("Checking email sender: " + fromEmail);
 
-    var fromEmailHash = sha256(fromEmail);
-    var fromEmailDomain = "";
-    var fromEmailDomainHash = "";
-    var fromEmailTopDomain = "";
-    var fromEmailTopDomainHash = "";
-
-    // We extract the domain from the email address.
-    var parts = fromEmail.split('@');
-    if (parts.length === 2) {
-        fromEmailDomain = getDomainFromURL(parts[1]);
-        fromEmailDomainHash = sha256(fromEmailDomain);
-        fromEmailTopDomain = getTopDomainFromURL(parts[1]);
-        fromEmailTopDomainHash = sha256(fromEmailTopDomain);
-    }
-
-    // First we get the list of indicators.
-    chrome.runtime.sendMessage({method: "getIndicators"}, function(response) {
-        // Fail if we don't have any indicators.
-        if (response == "") {
-            return false;
-        }
-        var indicators = response;
-
-        if (indicators === undefined) {
-            return false;
-        }
-
-        // Email status.
-        var isEmailBad = false;
-        var eventType = "";
-        var eventMatch = "";
-        var eventIndicator = "";
-
-        // We check for email addresses, if we have any indicators to check.
-        if (indicators.emails !== null) {
-            var itemsToCheck = [fromEmailHash,];
-            var matchedIndicator = checkForIndicators(itemsToCheck, indicators.emails);
-            if (matchedIndicator !== null) {
-                console.log("Detected bad email sender with indicator:", matchedIndicator);
-
-                // Mark email as bad.
-                isEmailBad = true;
-                eventType = "email_sender";
-                eventMatch = fromEmail;
-                eventIndicator = matchedIndicator;
-            }
-        }
-
-        if (indicators.domains !== null) {
-            // First we check the domain of the email sender.
-            var itemsToCheck = [fromEmailDomainHash, fromEmailTopDomainHash];
-            var matchedIndicator = checkForIndicators(itemsToCheck, indicators.domains);
-            if (matchedIndicator !== null) {
-                console.log("Detected email sender domain with indicator:", matchedIndicator);
-
-                isEmailBad = true;
-                eventType = "email_sender_domain";
-                eventMatch = fromEmail;
-                eventIndicator = matchedIndicator;
-            }
-
-            // Now we check for links in the email body.
-            var anchors = emailBody.find("a");
-
-            for (var i=0; i<anchors.length; i++) {
-                // Lowercase the link.
-                var href = anchors[i].href.toLowerCase();
-
-                // Only check for HTTP links.
-                // NOTE: also scanning for mailto: links (currently experimental).
-                if (href.indexOf("http://") != 0 && href.indexOf("https://") != 0 && href.indexOf("mailto:") != 0) {
-                    continue;
-                }
-
-                console.log("Checking link:", href);
-
-                var hrefDomain = getDomainFromURL(href);
-                var hrefDomainHash = sha256(hrefDomain);
-                var hrefTopDomain = getTopDomainFromURL(href);
-                var hrefTopDomainHash = sha256(hrefTopDomain);
-
-                // We loop through the list of hashed bad domains.
-                var elementsToCheck = [hrefDomainHash, hrefTopDomainHash];
-                var matchedIndicator = checkForIndicators(elementsToCheck, indicators.domains);
-                if (matchedIndicator !== null) {
-                    console.log("Detected bad link with indicator:", matchedIndicator);
-
-                    // We add a warning sign to the link.
-                    generateWebmailLinkWarning(anchors[i]);
-
-                    // Mark whole email as bad.
-                    // TODO: this is ugly.
-                    isEmailBad = true;
-                    eventType = "email_link";
-                    eventMatch = href;
-                    eventIndicator = matchedIndicator;
-
-                    break;
-                }
-            }
-        }
-
-        // TODO: this is ugly.
-        // If there is any malicious element we proceed with notifications.
-        if (isEmailBad === true) {
-            // First we send an "event" to the PhishDetect Node through the "sendEvent"
-            // message to the background script. This will proceed only if the
-            // appropriate settings option is enabled.
-            chrome.runtime.sendMessage({
-                method: "sendEvent",
-                eventType: eventType,
-                match: eventMatch,
-                indicator: eventIndicator,
-                identifier: uid,
-            });
-
-            // Then we display a warning to the user inside the Gmail web interface.
-            var warning = generateWebmailWarning(eventType);
-            emailBody.prepend(warning);
-        }
-    });
+    return checkEmail(fromEmail, emailBody, uid);
 }
 
 function roundcubeModifyEmail(email) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -82,7 +82,7 @@
                 "dist/domains.js",
                 "dist/gui.js",
                 "js/utils.js",
-                "js/roundcube.js",
+                "dist/roundcube.js",
                 "js/webmails.js"
             ],
             "css": [

--- a/src/ui/apikey/apikey.html
+++ b/src/ui/apikey/apikey.html
@@ -39,6 +39,6 @@
 <script src="../../js/const.js"></script>
 <script src="../../js/config.js"></script>
 <script src="../../js/i18n.js"></script>
-<script src="apikey.js"></script>
+<script src="../../dist/apikey.js"></script>
 </body>
 </html>

--- a/src/ui/apikey/apikey.js
+++ b/src/ui/apikey/apikey.js
@@ -15,6 +15,10 @@
 // You should have received a copy of the GNU General Public License
 // along with PhishDetect.  If not, see <https://www.gnu.org/licenses/>.
 
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { ApiKeySaved } from '../../components/ApiKey.js'
+
 $("form").submit(function(event) {
     event.preventDefault();
     var node = $("#server").val().trim();
@@ -26,13 +30,8 @@ $("form").submit(function(event) {
     if (apiKey != "") {
         cfg.setApiKey(apiKey);
 
-        $("#container").empty().append(
-            $("<div class=\"text-center\">")
-                .append($("<i class=\"fas fa-check-circle text-5xl text-green\">"))
-                .append($("<div class=\"mt-4\">")
-                    .text(chrome.i18n.getMessage("apikeySaved"))
-                )
-        );
+        var container = $("#container").empty();
+        ReactDOM.render(React.createElement(ApiKeySaved), container.get(0));
     } else {
         $("#errors").text(chrome.i18n.getMessage("apikeyErrorSecretToken"));
     }

--- a/src/ui/options/options.html
+++ b/src/ui/options/options.html
@@ -52,6 +52,6 @@
 <script src="../../js/i18n.js"></script>
 <script src="../../js/const.js"></script>
 <script src="../../js/config.js"></script>
-<script src="options.js"></script>
+<script src="../../dist/options.js"></script>
 </body>
 </html>

--- a/src/ui/options/options.js
+++ b/src/ui/options/options.js
@@ -15,6 +15,10 @@
 // You should have received a copy of the GNU General Public License
 // along with PhishDetect.  If not, see <https://www.gnu.org/licenses/>.
 
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { OptionsSaved } from '../../components/Options.js';
+
 function loadOptions() {
     $("#server").val(cfg.getNode());
     $("#webmails").prop("checked", cfg.getWebmails());
@@ -53,13 +57,8 @@ function saveOptions(event) {
     cfg.setReport($("#report").is(":checked"));
     cfg.setWebmails($("#webmails").is(":checked"));
 
-    $("#container").empty().append(
-        $("<div class=\"text-center\">")
-            .append($("<i class=\"fas fa-check-circle text-5xl text-green\">"))
-            .append($("<div class=\"mt-4\">")
-                .text(chrome.i18n.getMessage("optionsSaved"))
-            )
-    );
+    var container = $("#container").empty();
+    ReactDOM.render(React.createElement(OptionsSaved), container.get(0));
 }
 
 function restoreDefaults() {

--- a/src/ui/popup/popup.html
+++ b/src/ui/popup/popup.html
@@ -41,6 +41,6 @@
 <script src="../../js/i18n.js"></script>
 <script src="../../js/const.js"></script>
 <script src="../../js/config.js"></script>
-<script src="popup.js"></script>
+<script src="../../dist/popup.js"></script>
 </body>
 </html>

--- a/src/ui/popup/popup.js
+++ b/src/ui/popup/popup.js
@@ -15,6 +15,10 @@
 // You should have received a copy of the GNU General Public License
 // along with PhishDetect.  If not, see <https://www.gnu.org/licenses/>.
 
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { PopupActivate } from '../../components/Popup.js'
+
 function getTab(callback) {
     let url = new URL(window.location.href);
     if (url.searchParams.has("tabId")) {
@@ -42,15 +46,8 @@ function scanPage() {
 
 document.addEventListener("DOMContentLoaded", function () {
     if (cfg.getNodeEnforceUserAuth() === true && cfg.getApiKey() == "") {
-        $("#content").empty().append(
-            $("<p class=\"mt-4 leading-normal\">")
-                .text(chrome.i18n.getMessage("popupTokenRequired") + " ")
-                .append(
-                    $("<a href=\"/ui/apikey/apikey.html\">")
-                        .text(chrome.i18n.getMessage("popupActivate"))
-                )
-                .append(" <i class=\"far fa-smile text-blue\"></i>")
-        );
+        var container = $("#content").empty();
+        ReactDOM.render(React.createElement(PopupActivate), container.get(0));
         return;
     }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,11 @@ var options = {
     module: {
         rules: [
             {
+                test: /\.js$/,
+                loader: "babel-loader",
+                exclude: /node_modules/
+            },
+            {
                 test: /\.css$/,
                 loader: "style-loader!css-loader",
                 exclude: /node_modules/

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,9 @@ var webpack = require("webpack"),
 
 var fileExtensions = ["jpg", "jpeg", "png", "gif", "eot", "otf", "svg", "ttf", "woff", "woff2"];
 var options = {
+    devServer: {
+        publicPath: '/'
+    },
     mode: process.env.NODE_ENV || "development",
     entry: {
         gmail: path.join(__dirname, "src", "js", "gmail.js"),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,9 @@ var options = {
     },
     mode: process.env.NODE_ENV || "development",
     entry: {
+        popup: path.join(__dirname, "src", "ui", "popup", "popup.js"),
+        options: path.join(__dirname, "src", "ui", "options", "options.js"),
+        apikey: path.join(__dirname, "src", "ui", "apikey", "apikey.js"),
         gmail: path.join(__dirname, "src", "js", "gmail.js"),
         roundcube: path.join(__dirname, "src", "js", "roundcube.js"),
         domains: path.join(__dirname, "src", "js", "domains.js"),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ var options = {
     mode: process.env.NODE_ENV || "development",
     entry: {
         gmail: path.join(__dirname, "src", "js", "gmail.js"),
+        roundcube: path.join(__dirname, "src", "js", "roundcube.js"),
         domains: path.join(__dirname, "src", "js", "domains.js"),
         gui: path.join(__dirname, "src", "js", "gui.js")
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -452,6 +452,40 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
+babel-code-frame@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
+  integrity sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=
+  dependencies:
+    chalk "^1.1.3"
+    esutils "^2.0.2"
+    js-tokens "^3.0.2"
+
+babel-core@^6.26.0, babel-core@^6.26.3:
+  version "6.26.3"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
+  integrity sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-generator "^6.26.0"
+    babel-helpers "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-register "^6.26.0"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    convert-source-map "^1.5.1"
+    debug "^2.6.9"
+    json5 "^0.5.1"
+    lodash "^4.17.4"
+    minimatch "^3.0.4"
+    path-is-absolute "^1.0.1"
+    private "^0.1.8"
+    slash "^1.0.0"
+    source-map "^0.5.7"
+
 babel-extract-comments@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz#0a2aedf81417ed391b85e18b4614e693a0351a21"
@@ -459,10 +493,410 @@ babel-extract-comments@^1.0.0:
   dependencies:
     babylon "^6.18.0"
 
+babel-generator@^6.26.0:
+  version "6.26.1"
+  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
+  integrity sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==
+  dependencies:
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    detect-indent "^4.0.0"
+    jsesc "^1.3.0"
+    lodash "^4.17.4"
+    source-map "^0.5.7"
+    trim-right "^1.0.1"
+
+babel-helper-builder-binary-assignment-operator-visitor@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz#cce4517ada356f4220bcae8a02c2b346f9a56664"
+  integrity sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=
+  dependencies:
+    babel-helper-explode-assignable-expression "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-helper-builder-react-jsx@^6.24.1:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz#39ff8313b75c8b65dceff1f31d383e0ff2a408a0"
+  integrity sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    esutils "^2.0.2"
+
+babel-helper-call-delegate@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz#ece6aacddc76e41c3461f88bfc575bd0daa2df8d"
+  integrity sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=
+  dependencies:
+    babel-helper-hoist-variables "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-define-map@^6.24.1:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz#a5f56dab41a25f97ecb498c7ebaca9819f95be5f"
+  integrity sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    lodash "^4.17.4"
+
+babel-helper-explode-assignable-expression@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz#f25b82cf7dc10433c55f70592d5746400ac22caa"
+  integrity sha1-8luCz33BBDPFX3BZLVdGQArCLKo=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-function-name@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz#d3475b8c03ed98242a25b48351ab18399d3580a9"
+  integrity sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=
+  dependencies:
+    babel-helper-get-function-arity "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-get-function-arity@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz#8f7782aa93407c41d3aa50908f89b031b1b6853d"
+  integrity sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-helper-hoist-variables@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz#1ecb27689c9d25513eadbc9914a73f5408be7a76"
+  integrity sha1-HssnaJydJVE+rbyZFKc/VAi+enY=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-helper-optimise-call-expression@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz#f7a13427ba9f73f8f4fa993c54a97882d1244257"
+  integrity sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-helper-regex@^6.24.1:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz#325c59f902f82f24b74faceed0363954f6495e72"
+  integrity sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    lodash "^4.17.4"
+
+babel-helper-remap-async-to-generator@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz#5ec581827ad723fecdd381f1c928390676e4551b"
+  integrity sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-replace-supers@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz#bf6dbfe43938d17369a213ca8a8bf74b6a90ab1a"
+  integrity sha1-v22/5Dk40XNpohPKiov3S2qQqxo=
+  dependencies:
+    babel-helper-optimise-call-expression "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helpers@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helpers/-/babel-helpers-6.24.1.tgz#3471de9caec388e5c850e597e58a26ddf37602b2"
+  integrity sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-loader@7:
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.1.5.tgz#e3ee0cd7394aa557e013b02d3e492bfd07aa6d68"
+  integrity sha512-iCHfbieL5d1LfOQeeVJEUyD9rTwBcP/fcEbRCfempxTDuqrKpu0AZjLAQHEQa3Yqyj9ORKe2iHfoj4rHLf7xpw==
+  dependencies:
+    find-cache-dir "^1.0.0"
+    loader-utils "^1.0.2"
+    mkdirp "^0.5.1"
+
+babel-messages@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
+  integrity sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-check-es2015-constants@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
+  integrity sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-syntax-async-functions@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
+  integrity sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=
+
+babel-plugin-syntax-exponentiation-operator@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
+  integrity sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=
+
+babel-plugin-syntax-flow@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
+  integrity sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=
+
+babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
+  integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
+
 babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
   integrity sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=
+
+babel-plugin-syntax-trailing-function-commas@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
+  integrity sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=
+
+babel-plugin-transform-async-to-generator@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz#6536e378aff6cb1d5517ac0e40eb3e9fc8d08761"
+  integrity sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=
+  dependencies:
+    babel-helper-remap-async-to-generator "^6.24.1"
+    babel-plugin-syntax-async-functions "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-arrow-functions@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz#452692cb711d5f79dc7f85e440ce41b9f244d221"
+  integrity sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-block-scoped-functions@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz#bbc51b49f964d70cb8d8e0b94e820246ce3a6141"
+  integrity sha1-u8UbSflk1wy42OC5ToICRs46YUE=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-block-scoping@^6.23.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz#d70f5299c1308d05c12f463813b0a09e73b1895f"
+  integrity sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    lodash "^4.17.4"
+
+babel-plugin-transform-es2015-classes@^6.23.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz#5a4c58a50c9c9461e564b4b2a3bfabc97a2584db"
+  integrity sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=
+  dependencies:
+    babel-helper-define-map "^6.24.1"
+    babel-helper-function-name "^6.24.1"
+    babel-helper-optimise-call-expression "^6.24.1"
+    babel-helper-replace-supers "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-computed-properties@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz#6fe2a8d16895d5634f4cd999b6d3480a308159b3"
+  integrity sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-es2015-destructuring@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz#997bb1f1ab967f682d2b0876fe358d60e765c56d"
+  integrity sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-duplicate-keys@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz#73eb3d310ca969e3ef9ec91c53741a6f1576423e"
+  integrity sha1-c+s9MQypaePvnskcU3QabxV2Qj4=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-for-of@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz#f47c95b2b613df1d3ecc2fdb7573623c75248691"
+  integrity sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-function-name@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz#834c89853bc36b1af0f3a4c5dbaa94fd8eacaa8b"
+  integrity sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-literals@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz#4f54a02d6cd66cf915280019a31d31925377ca2e"
+  integrity sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-modules-amd@^6.22.0, babel-plugin-transform-es2015-modules-amd@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz#3b3e54017239842d6d19c3011c4bd2f00a00d154"
+  integrity sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=
+  dependencies:
+    babel-plugin-transform-es2015-modules-commonjs "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-es2015-modules-commonjs@^6.23.0, babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
+  version "6.26.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz#58a793863a9e7ca870bdc5a881117ffac27db6f3"
+  integrity sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==
+  dependencies:
+    babel-plugin-transform-strict-mode "^6.24.1"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-types "^6.26.0"
+
+babel-plugin-transform-es2015-modules-systemjs@^6.23.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz#ff89a142b9119a906195f5f106ecf305d9407d23"
+  integrity sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=
+  dependencies:
+    babel-helper-hoist-variables "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-es2015-modules-umd@^6.23.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz#ac997e6285cd18ed6176adb607d602344ad38468"
+  integrity sha1-rJl+YoXNGO1hdq22B9YCNErThGg=
+  dependencies:
+    babel-plugin-transform-es2015-modules-amd "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-es2015-object-super@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz#24cef69ae21cb83a7f8603dad021f572eb278f8d"
+  integrity sha1-JM72muIcuDp/hgPa0CH1cusnj40=
+  dependencies:
+    babel-helper-replace-supers "^6.24.1"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-parameters@^6.23.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz#57ac351ab49caf14a97cd13b09f66fdf0a625f2b"
+  integrity sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=
+  dependencies:
+    babel-helper-call-delegate "^6.24.1"
+    babel-helper-get-function-arity "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-shorthand-properties@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz#24f875d6721c87661bbd99a4622e51f14de38aa0"
+  integrity sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-spread@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz#d6d68a99f89aedc4536c81a542e8dd9f1746f8d1"
+  integrity sha1-1taKmfia7cRTbIGlQujdnxdG+NE=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-sticky-regex@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz#00c1cdb1aca71112cdf0cf6126c2ed6b457ccdbc"
+  integrity sha1-AMHNsaynERLN8M9hJsLta0V8zbw=
+  dependencies:
+    babel-helper-regex "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-template-literals@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz#a84b3450f7e9f8f1f6839d6d687da84bb1236d8d"
+  integrity sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-typeof-symbol@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz#dec09f1cddff94b52ac73d505c84df59dcceb372"
+  integrity sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-unicode-regex@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz#d38b12f42ea7323f729387f18a7c5ae1faeb35e9"
+  integrity sha1-04sS9C6nMj9yk4fxinxa4frrNek=
+  dependencies:
+    babel-helper-regex "^6.24.1"
+    babel-runtime "^6.22.0"
+    regexpu-core "^2.0.0"
+
+babel-plugin-transform-exponentiation-operator@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz#2ab0c9c7f3098fa48907772bb813fe41e8de3a0e"
+  integrity sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=
+  dependencies:
+    babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
+    babel-plugin-syntax-exponentiation-operator "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-flow-strip-types@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz#84cb672935d43714fdc32bce84568d87441cf7cf"
+  integrity sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=
+  dependencies:
+    babel-plugin-syntax-flow "^6.18.0"
+    babel-runtime "^6.22.0"
 
 babel-plugin-transform-object-rest-spread@^6.26.0:
   version "6.26.0"
@@ -472,13 +906,164 @@ babel-plugin-transform-object-rest-spread@^6.26.0:
     babel-plugin-syntax-object-rest-spread "^6.8.0"
     babel-runtime "^6.26.0"
 
-babel-runtime@^6.26.0:
+babel-plugin-transform-react-display-name@^6.23.0:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz#67e2bf1f1e9c93ab08db96792e05392bf2cc28d1"
+  integrity sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-react-jsx-self@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz#df6d80a9da2612a121e6ddd7558bcbecf06e636e"
+  integrity sha1-322AqdomEqEh5t3XVYvL7PBuY24=
+  dependencies:
+    babel-plugin-syntax-jsx "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-react-jsx-source@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz#66ac12153f5cd2d17b3c19268f4bf0197f44ecd6"
+  integrity sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=
+  dependencies:
+    babel-plugin-syntax-jsx "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-react-jsx@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz#840a028e7df460dfc3a2d29f0c0d91f6376e66a3"
+  integrity sha1-hAoCjn30YN/DotKfDA2R9jduZqM=
+  dependencies:
+    babel-helper-builder-react-jsx "^6.24.1"
+    babel-plugin-syntax-jsx "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-regenerator@^6.22.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"
+  integrity sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=
+  dependencies:
+    regenerator-transform "^0.10.0"
+
+babel-plugin-transform-strict-mode@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"
+  integrity sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-preset-env@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.7.0.tgz#dea79fa4ebeb883cd35dab07e260c1c9c04df77a"
+  integrity sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==
+  dependencies:
+    babel-plugin-check-es2015-constants "^6.22.0"
+    babel-plugin-syntax-trailing-function-commas "^6.22.0"
+    babel-plugin-transform-async-to-generator "^6.22.0"
+    babel-plugin-transform-es2015-arrow-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoped-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoping "^6.23.0"
+    babel-plugin-transform-es2015-classes "^6.23.0"
+    babel-plugin-transform-es2015-computed-properties "^6.22.0"
+    babel-plugin-transform-es2015-destructuring "^6.23.0"
+    babel-plugin-transform-es2015-duplicate-keys "^6.22.0"
+    babel-plugin-transform-es2015-for-of "^6.23.0"
+    babel-plugin-transform-es2015-function-name "^6.22.0"
+    babel-plugin-transform-es2015-literals "^6.22.0"
+    babel-plugin-transform-es2015-modules-amd "^6.22.0"
+    babel-plugin-transform-es2015-modules-commonjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-systemjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-umd "^6.23.0"
+    babel-plugin-transform-es2015-object-super "^6.22.0"
+    babel-plugin-transform-es2015-parameters "^6.23.0"
+    babel-plugin-transform-es2015-shorthand-properties "^6.22.0"
+    babel-plugin-transform-es2015-spread "^6.22.0"
+    babel-plugin-transform-es2015-sticky-regex "^6.22.0"
+    babel-plugin-transform-es2015-template-literals "^6.22.0"
+    babel-plugin-transform-es2015-typeof-symbol "^6.23.0"
+    babel-plugin-transform-es2015-unicode-regex "^6.22.0"
+    babel-plugin-transform-exponentiation-operator "^6.22.0"
+    babel-plugin-transform-regenerator "^6.22.0"
+    browserslist "^3.2.6"
+    invariant "^2.2.2"
+    semver "^5.3.0"
+
+babel-preset-flow@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz#e71218887085ae9a24b5be4169affb599816c49d"
+  integrity sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=
+  dependencies:
+    babel-plugin-transform-flow-strip-types "^6.22.0"
+
+babel-preset-react@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-react/-/babel-preset-react-6.24.1.tgz#ba69dfaea45fc3ec639b6a4ecea6e17702c91380"
+  integrity sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=
+  dependencies:
+    babel-plugin-syntax-jsx "^6.3.13"
+    babel-plugin-transform-react-display-name "^6.23.0"
+    babel-plugin-transform-react-jsx "^6.24.1"
+    babel-plugin-transform-react-jsx-self "^6.22.0"
+    babel-plugin-transform-react-jsx-source "^6.22.0"
+    babel-preset-flow "^6.23.0"
+
+babel-register@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
+  integrity sha1-btAhFz4vy0htestFxgCahW9kcHE=
+  dependencies:
+    babel-core "^6.26.0"
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    home-or-tmp "^2.0.0"
+    lodash "^4.17.4"
+    mkdirp "^0.5.1"
+    source-map-support "^0.4.15"
+
+babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
+
+babel-template@^6.24.1, babel-template@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
+  integrity sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    lodash "^4.17.4"
+
+babel-traverse@^6.24.1, babel-traverse@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
+  integrity sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    debug "^2.6.8"
+    globals "^9.18.0"
+    invariant "^2.2.2"
+    lodash "^4.17.4"
+
+babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
+  integrity sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=
+  dependencies:
+    babel-runtime "^6.26.0"
+    esutils "^2.0.2"
+    lodash "^4.17.4"
+    to-fast-properties "^1.0.3"
 
 babylon@^6.18.0:
   version "6.18.0"
@@ -695,6 +1280,14 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
+browserslist@^3.2.6:
+  version "3.2.8"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.2.8.tgz#b0005361d6471f0f5952797a76fc985f1f978fc6"
+  integrity sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==
+  dependencies:
+    caniuse-lite "^1.0.30000844"
+    electron-to-chromium "^1.3.47"
+
 browserslist@^4.6.3:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.7.0.tgz#9ee89225ffc07db03409f2fee524dc8227458a17"
@@ -861,6 +1454,11 @@ camelcase@^5.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
   integrity sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==
 
+caniuse-lite@^1.0.30000844:
+  version "1.0.30001008"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001008.tgz#b8841b1df78a9f5ed9702537ef592f1f8772c0d9"
+  integrity sha512-b8DJyb+VVXZGRgJUa30cbk8gKHZ3LOZTBLaUEEVr2P4xpmFigOCc62CO4uzquW641Ouq1Rm9N+rWLWdSYDaDIw==
+
 caniuse-lite@^1.0.30000980, caniuse-lite@^1.0.30000989:
   version "1.0.30000997"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000997.tgz#ba44a606804f8680894b7042612c2c7f65685b7e"
@@ -921,7 +1519,7 @@ chownr@^1.0.1, chownr@^1.1.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
   integrity sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==
 
-chownr@^1.1.2:
+chownr@^1.1.2, chownr@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.3.tgz#42d837d5239688d55f303003a508230fa6727142"
   integrity sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==
@@ -1184,6 +1782,13 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
+convert-source-map@^1.5.1:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
+  integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
+  dependencies:
+    safe-buffer "~5.1.1"
+
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
@@ -1225,7 +1830,7 @@ copy-webpack-plugin@^4.6.0:
     p-limit "^1.0.0"
     serialize-javascript "^1.4.0"
 
-core-js@^2.4.0:
+core-js@^2.4.0, core-js@^2.5.0:
   version "2.6.10"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.10.tgz#8a5b8391f8cc7013da703411ce5b585706300d7f"
   integrity sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==
@@ -1387,7 +1992,7 @@ date-now@^0.1.4:
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
   integrity sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=
 
-debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3:
+debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -1545,6 +2150,13 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
   integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
+
+detect-indent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
+  integrity sha1-920GQ1LN9Docts5hnE7jqUdd4gg=
+  dependencies:
+    repeating "^2.0.0"
 
 detect-indent@~5.0.0:
   version "5.0.0"
@@ -1717,6 +2329,11 @@ electron-to-chromium@^1.3.247:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.270.tgz#a3faa2c51f73bf7a020370b3e28a99b32eae47ed"
   integrity sha512-426qbfgLn0hVE4pDxok2dcAhA3u5lwXlBg2+i6VWQJvnMZNgevkC6s/qr91YH/avVMKXKwxnR5iBznpivg210A==
 
+electron-to-chromium@^1.3.47:
+  version "1.3.306"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.306.tgz#e8265301d053d5f74e36cb876486830261fbe946"
+  integrity sha512-frDqXvrIROoYvikSKTIKbHbzO6M3/qC6kCIt/1FOa9kALe++c4VAJnwjSFvf1tYLEUsP2n9XZ4XSCyqc3l7A/A==
+
 elliptic@^6.0.0:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.1.tgz#c2d0b7776911b86722c632c3c06c60f2f819939a"
@@ -1865,6 +2482,11 @@ estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
   integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
+
+esutils@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
+  integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
 etag@~1.8.1:
   version "1.8.1"
@@ -2419,6 +3041,11 @@ global-prefix@^1.0.1:
     is-windows "^1.0.1"
     which "^1.2.14"
 
+globals@^9.18.0:
+  version "9.18.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
+  integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
+
 globby@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
@@ -2471,10 +3098,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
-graceful-fs@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
-  integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
+graceful-fs@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
+  integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
 
 handle-thing@^2.0.0:
   version "2.0.0"
@@ -2589,6 +3216,14 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
+home-or-tmp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
+  integrity sha1-42w/LSyufXRqhX440Y1fMqeILbg=
+  dependencies:
+    os-homedir "^1.0.0"
+    os-tmpdir "^1.0.1"
+
 homedir-polyfill@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
@@ -2596,10 +3231,15 @@ homedir-polyfill@^1.0.1:
   dependencies:
     parse-passwd "^1.0.0"
 
-hosted-git-info@^2.1.4, hosted-git-info@^2.7.1, hosted-git-info@^2.8.2:
+hosted-git-info@^2.1.4, hosted-git-info@^2.7.1:
   version "2.8.4"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.4.tgz#44119abaf4bc64692a16ace34700fed9c03e2546"
   integrity sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==
+
+hosted-git-info@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.5.tgz#759cfcf2c4d156ade59b0b2dfabddc42a6b9c70c"
+  integrity sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==
 
 hpack.js@^2.1.6:
   version "2.1.6"
@@ -2885,6 +3525,13 @@ interpret@^1.1.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
+invariant@^2.2.2:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
+  dependencies:
+    loose-envify "^1.0.0"
+
 invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
@@ -3013,6 +3660,13 @@ is-extglob@^2.1.0, is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
+
+is-finite@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
+  integrity sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=
+  dependencies:
+    number-is-nan "^1.0.0"
 
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
@@ -3182,10 +3836,25 @@ js-sha256@^0.9.0:
   resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.9.0.tgz#0b89ac166583e91ef9123644bd3c5334ce9d0966"
   integrity sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
+js-tokens@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+  integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
+
+jsesc@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
+  integrity sha1-RsP+yMGJKxKwgz25vHYiF226s0s=
 
 jsesc@~0.5.0:
   version "0.5.0"
@@ -3217,7 +3886,7 @@ json3@^3.3.2:
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
   integrity sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=
 
-json5@^0.5.0:
+json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
   integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
@@ -3306,10 +3975,10 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
-libcipm@^4.0.3:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/libcipm/-/libcipm-4.0.4.tgz#6d28fd0f31e61963f8ec7125e9247349181f6cf4"
-  integrity sha512-S2hmT4tYXTpq1H98K+gm/fujDcgQKqPz0QwkmtKrGklAo7U0DI9ZYmQq/EahF3sqw33Quv9gMHJGeodqyX23kg==
+libcipm@^4.0.7:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/libcipm/-/libcipm-4.0.7.tgz#76cd675c98bdaae64db88b782b01b804b6d02c8a"
+  integrity sha512-fTq33otU3PNXxxCTCYCYe7V96o59v/o7bvtspmbORXpgFk+wcWrGf5x6tBgui5gCed/45/wtPomBsZBYm5KbIw==
   dependencies:
     bin-links "^1.1.2"
     bluebird "^3.5.1"
@@ -3548,7 +4217,7 @@ lodash.without@~4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
   integrity sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=
 
-lodash@^4.17.11, lodash@^4.17.3, lodash@^4.17.5:
+lodash@^4.17.11, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -3557,6 +4226,13 @@ loglevel@^1.4.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
   integrity sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=
+
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 lower-case@^1.1.1:
   version "1.1.4"
@@ -3981,10 +4657,27 @@ node-forge@0.7.5:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.5.tgz#6c152c345ce11c52f465c2abd957e8639cd674df"
   integrity sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ==
 
-node-gyp@^5.0.2, node-gyp@^5.0.3:
+node-gyp@^5.0.2:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-5.0.4.tgz#1de243f17b081a6e89f4330967900c816114f8fb"
   integrity sha512-PMYap4ekQckQDZ2lxoORUF/nX13haU1JdCAlmLgvrykLyN0LFkhfwPbWhYjTxwTruCWbTkeOxFo043kjhmKHZA==
+  dependencies:
+    env-paths "^1.0.0"
+    glob "^7.0.3"
+    graceful-fs "^4.1.2"
+    mkdirp "^0.5.0"
+    nopt "2 || 3"
+    npmlog "0 || 1 || 2 || 3 || 4"
+    request "^2.87.0"
+    rimraf "2"
+    semver "~5.3.0"
+    tar "^4.4.12"
+    which "1"
+
+node-gyp@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-5.0.5.tgz#f6cf1da246eb8c42b097d7cd4d6c3ce23a4163af"
+  integrity sha512-WABl9s4/mqQdZneZHVWVG4TVr6QQJZUC6PAx47ITSk9lreZ1n+7Z9mMAIbA3vnO4J9W20P7LhCxtzfWsAD/KDw==
   dependencies:
     env-paths "^1.0.0"
     glob "^7.0.3"
@@ -4105,14 +4798,14 @@ npm-cache-filename@~1.0.2:
   resolved "https://registry.yarnpkg.com/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz#ded306c5b0bfc870a9e9faf823bc5f283e05ae11"
   integrity sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=
 
-npm-install-checks@~3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/npm-install-checks/-/npm-install-checks-3.0.0.tgz#d4aecdfd51a53e3723b7b2f93b2ee28e307bc0d7"
-  integrity sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=
+npm-install-checks@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/npm-install-checks/-/npm-install-checks-3.0.2.tgz#ab2e32ad27baa46720706908e5b14c1852de44d9"
+  integrity sha512-E4kzkyZDIWoin6uT5howP8VDvkM+E8IQDcHAycaAxMbwkqhIg5eEYALnXOl3Hq9MrkdQB/2/g1xwBINXdKSRkg==
   dependencies:
     semver "^2.3.0 || 3.x || 4 || 5"
 
-npm-lifecycle@^3.0.0, npm-lifecycle@^3.1.3:
+npm-lifecycle@^3.0.0, npm-lifecycle@^3.1.4:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/npm-lifecycle/-/npm-lifecycle-3.1.4.tgz#de6975c7d8df65f5150db110b57cce498b0b604c"
   integrity sha512-tgs1PaucZwkxECGKhC/stbEgFyc3TGh2TJcg2CDr6jbvQRdteHNhmMeljRzpe4wgFAXQADoy1cSqqi7mtiAa5A==
@@ -4141,7 +4834,7 @@ npm-logical-tree@^1.2.1:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.12, npm-packlist@^1.4.4:
+npm-packlist@^1.1.12:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.4.tgz#866224233850ac534b63d1a6e76050092b5d2f44"
   integrity sha512-zTLo8UcVYtDU3gdeaFu2Xu0n0EvelfHDGuqtNIn5RO7yQj4H1TqNdBc/yZjxnWA0PVB8D3Woyp0i5B43JwQ6Vw==
@@ -4153,6 +4846,14 @@ npm-packlist@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.2.0.tgz#55a60e793e272f00862c7089274439a4cc31fc7f"
   integrity sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==
+  dependencies:
+    ignore-walk "^3.0.1"
+    npm-bundled "^1.0.1"
+
+npm-packlist@^1.4.6:
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.6.tgz#53ba3ed11f8523079f1457376dd379ee4ea42ff4"
+  integrity sha512-u65uQdb+qwtGvEJh/DgQgW1Xg7sqeNbmxYyrvlNznaVTjV3E5P6F/EFjM+BVHXl7JJlsdG8A64M0XI8FI/IOlg==
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
@@ -4188,6 +4889,19 @@ npm-registry-fetch@^4.0.0:
     npm-package-arg "^6.1.0"
     safe-buffer "^5.2.0"
 
+npm-registry-fetch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/npm-registry-fetch/-/npm-registry-fetch-4.0.2.tgz#2b1434f93ccbe6b6385f8e45f45db93e16921d7a"
+  integrity sha512-Z0IFtPEozNdeZRPh3aHHxdG+ZRpzcbQaJLthsm3VhNf6DScicTFRHZzK82u8RsJUsUHkX+QH/zcB/5pmd20H4A==
+  dependencies:
+    JSONStream "^1.3.4"
+    bluebird "^3.5.1"
+    figgy-pudding "^3.4.1"
+    lru-cache "^5.1.1"
+    make-fetch-happen "^5.0.0"
+    npm-package-arg "^6.1.0"
+    safe-buffer "^5.2.0"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -4200,10 +4914,10 @@ npm-user-validate@~1.0.0:
   resolved "https://registry.yarnpkg.com/npm-user-validate/-/npm-user-validate-1.0.0.tgz#8ceca0f5cea04d4e93519ef72d0557a75122e951"
   integrity sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=
 
-npm@^6.10.1:
-  version "6.11.3"
-  resolved "https://registry.yarnpkg.com/npm/-/npm-6.11.3.tgz#730f46b7cc5bbc6f04dd57b5699be0c9f2359dda"
-  integrity sha512-K2h+MPzZiY39Xf6eHEdECe/LKoJXam4UCflz5kIxoskN3LQFeYs5fqBGT5i4TtM/aBk+86Mcf+jgXs/WuWAutQ==
+npm@^6.12.1:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/npm/-/npm-6.13.0.tgz#2e90fa5b2f759017d906aa7583f0e9ed6e80e2e2"
+  integrity sha512-zjSJ8zjk0cDBZXqTWbQ6+qOdm1m2k489YDFP60RQRUhOxT5LOBhl+cDtFlEXEIblcNjofmsZ/qQ/wzmn5frimQ==
   dependencies:
     JSONStream "^1.3.5"
     abbrev "~1.1.1"
@@ -4216,7 +4930,7 @@ npm@^6.10.1:
     byte-size "^5.0.1"
     cacache "^12.0.3"
     call-limit "^1.1.1"
-    chownr "^1.1.2"
+    chownr "^1.1.3"
     ci-info "^2.0.0"
     cli-columns "^3.1.2"
     cli-table3 "^0.5.1"
@@ -4233,9 +4947,9 @@ npm@^6.10.1:
     fs-write-stream-atomic "~1.0.10"
     gentle-fs "^2.2.1"
     glob "^7.1.4"
-    graceful-fs "^4.2.2"
+    graceful-fs "^4.2.3"
     has-unicode "~2.0.1"
-    hosted-git-info "^2.8.2"
+    hosted-git-info "^2.8.5"
     iferr "^1.0.2"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
@@ -4245,7 +4959,7 @@ npm@^6.10.1:
     is-cidr "^3.0.0"
     json-parse-better-errors "^1.0.2"
     lazy-property "~1.0.0"
-    libcipm "^4.0.3"
+    libcipm "^4.0.7"
     libnpm "^3.0.1"
     libnpmaccess "^3.0.2"
     libnpmhook "^5.0.3"
@@ -4265,31 +4979,31 @@ npm@^6.10.1:
     mississippi "^3.0.0"
     mkdirp "~0.5.1"
     move-concurrently "^1.0.1"
-    node-gyp "^5.0.3"
+    node-gyp "^5.0.5"
     nopt "~4.0.1"
     normalize-package-data "^2.5.0"
     npm-audit-report "^1.3.2"
     npm-cache-filename "~1.0.2"
-    npm-install-checks "~3.0.0"
-    npm-lifecycle "^3.1.3"
+    npm-install-checks "^3.0.2"
+    npm-lifecycle "^3.1.4"
     npm-package-arg "^6.1.1"
-    npm-packlist "^1.4.4"
+    npm-packlist "^1.4.6"
     npm-pick-manifest "^3.0.2"
     npm-profile "^4.0.2"
-    npm-registry-fetch "^4.0.0"
+    npm-registry-fetch "^4.0.2"
     npm-user-validate "~1.0.0"
     npmlog "~4.1.2"
     once "~1.4.0"
     opener "^1.5.1"
     osenv "^0.1.5"
-    pacote "^9.5.8"
+    pacote "^9.5.9"
     path-is-inside "~1.0.2"
     promise-inflight "~1.0.1"
     qrcode-terminal "^0.12.0"
     query-string "^6.8.2"
     qw "~1.0.1"
     read "~1.0.7"
-    read-cmd-shim "^1.0.4"
+    read-cmd-shim "^1.0.5"
     read-installed "~4.0.3"
     read-package-json "^2.1.0"
     read-package-tree "^5.3.1"
@@ -4305,8 +5019,8 @@ npm@^6.10.1:
     sorted-object "~2.0.1"
     sorted-union-stream "~2.1.3"
     ssri "^6.0.1"
-    stringify-package "^1.0.0"
-    tar "^4.4.10"
+    stringify-package "^1.0.1"
+    tar "^4.4.13"
     text-table "~0.2.0"
     tiny-relative-date "^1.3.0"
     uid-number "0.0.6"
@@ -4314,7 +5028,7 @@ npm@^6.10.1:
     unique-filename "^1.1.1"
     unpipe "~1.0.0"
     update-notifier "^2.5.0"
-    uuid "^3.3.2"
+    uuid "^3.3.3"
     validate-npm-package-license "^3.0.4"
     validate-npm-package-name "~3.0.0"
     which "^1.3.1"
@@ -4465,7 +5179,7 @@ os-locale@^3.0.0:
     lcid "^2.0.0"
     mem "^4.0.0"
 
-os-tmpdir@^1.0.0:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
@@ -4546,10 +5260,45 @@ package-json@^4.0.0:
     registry-url "^3.0.3"
     semver "^5.1.0"
 
-pacote@^9.1.0, pacote@^9.5.3, pacote@^9.5.8:
+pacote@^9.1.0, pacote@^9.5.3:
   version "9.5.8"
   resolved "https://registry.yarnpkg.com/pacote/-/pacote-9.5.8.tgz#23480efdc4fa74515855c9ecf39cf64078f99786"
   integrity sha512-0Tl8Oi/K0Lo4MZmH0/6IsT3gpGf9eEAznLXEQPKgPq7FscnbUOyopnVpwXlnQdIbCUaojWy1Wd7VMyqfVsRrIw==
+  dependencies:
+    bluebird "^3.5.3"
+    cacache "^12.0.2"
+    chownr "^1.1.2"
+    figgy-pudding "^3.5.1"
+    get-stream "^4.1.0"
+    glob "^7.1.3"
+    infer-owner "^1.0.4"
+    lru-cache "^5.1.1"
+    make-fetch-happen "^5.0.0"
+    minimatch "^3.0.4"
+    minipass "^2.3.5"
+    mississippi "^3.0.0"
+    mkdirp "^0.5.1"
+    normalize-package-data "^2.4.0"
+    npm-package-arg "^6.1.0"
+    npm-packlist "^1.1.12"
+    npm-pick-manifest "^3.0.0"
+    npm-registry-fetch "^4.0.0"
+    osenv "^0.1.5"
+    promise-inflight "^1.0.1"
+    promise-retry "^1.1.1"
+    protoduck "^5.0.1"
+    rimraf "^2.6.2"
+    safe-buffer "^5.1.2"
+    semver "^5.6.0"
+    ssri "^6.0.1"
+    tar "^4.4.10"
+    unique-filename "^1.1.1"
+    which "^1.3.1"
+
+pacote@^9.5.9:
+  version "9.5.9"
+  resolved "https://registry.yarnpkg.com/pacote/-/pacote-9.5.9.tgz#fa3a08629c9390b2b99769c55b2cc137e1a24df3"
+  integrity sha512-S1nYW9ly+3btn3VmwRAk2LG3TEh8mkrFdY+psbnHSk8oPODbZ28uG0Z0d3yI0EpqcpLR6BukoVRf3H4IbGCkPQ==
   dependencies:
     bluebird "^3.5.3"
     cacache "^12.0.2"
@@ -4643,7 +5392,7 @@ path-exists@^3.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
   integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
 
-path-is-absolute@^1.0.0:
+path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
@@ -4896,7 +5645,7 @@ pretty-hrtime@^1.0.3:
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
 
-private@~0.1.5:
+private@^0.1.6, private@^0.1.8, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
   integrity sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==
@@ -4930,6 +5679,15 @@ promzard@^0.3.0:
   integrity sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=
   dependencies:
     read "1"
+
+prop-types@^15.6.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
 
 proto-list@~1.2.1:
   version "1.2.4"
@@ -5097,10 +5855,41 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-read-cmd-shim@^1.0.1, read-cmd-shim@^1.0.4:
+react-dom@^16.11.0:
+  version "16.11.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.11.0.tgz#7e7c4a5a85a569d565c2462f5d345da2dd849af5"
+  integrity sha512-nrRyIUE1e7j8PaXSPtyRKtz+2y9ubW/ghNgqKFHHAHaeP0fpF5uXR+sq8IMRHC+ZUxw7W9NyCDTBtwWxvkb0iA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.17.0"
+
+react-is@^16.8.1:
+  version "16.11.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.11.0.tgz#b85dfecd48ad1ce469ff558a882ca8e8313928fa"
+  integrity sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw==
+
+react@^16.11.0:
+  version "16.11.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.11.0.tgz#d294545fe62299ccee83363599bf904e4a07fdbb"
+  integrity sha512-M5Y8yITaLmU0ynd0r1Yvfq98Rmll6q8AxaEe88c8e7LxO8fZ2cNgmFt0aGAS9wzf1Ao32NKXtCl+/tVVtkxq6g==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+
+read-cmd-shim@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/read-cmd-shim/-/read-cmd-shim-1.0.4.tgz#b4a53d43376211b45243f0072b6e603a8e37640d"
   integrity sha512-Pqpl3qJ/QdOIjRYA0q5DND/gLvGOfpIz/fYVDGYpOXfW/lFrIttmLsBnd6IkyK10+JHU9zhsaudfvrQTBB9YFQ==
+  dependencies:
+    graceful-fs "^4.1.2"
+
+read-cmd-shim@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/read-cmd-shim/-/read-cmd-shim-1.0.5.tgz#87e43eba50098ba5a32d0ceb583ab8e43b961c16"
+  integrity sha512-v5yCqQ/7okKoZZkBQUAfTsQ3sVJtXdNfbPnI5cceppoxEVLYA3k+VtV2omkeo8MS94JCy4fSiUwlRBAwCVRPUA==
   dependencies:
     graceful-fs "^4.1.2"
 
@@ -5243,6 +6032,15 @@ regenerator-runtime@^0.11.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
+regenerator-transform@^0.10.0:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.10.1.tgz#1e4996837231da8b7f3cf4114d71b5691a0680dd"
+  integrity sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==
+  dependencies:
+    babel-runtime "^6.18.0"
+    babel-types "^6.19.0"
+    private "^0.1.6"
+
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
@@ -5255,6 +6053,15 @@ regexpu-core@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-1.0.0.tgz#86a763f58ee4d7c2f6b102e4764050de7ed90c6b"
   integrity sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=
+  dependencies:
+    regenerate "^1.2.1"
+    regjsgen "^0.2.0"
+    regjsparser "^0.1.4"
+
+regexpu-core@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240"
+  integrity sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=
   dependencies:
     regenerate "^1.2.1"
     regjsgen "^0.2.0"
@@ -5317,6 +6124,13 @@ repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
+
+repeating@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
+  integrity sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=
+  dependencies:
+    is-finite "^1.0.0"
 
 request@^2.87.0, request@^2.88.0:
   version "2.88.0"
@@ -5466,6 +6280,14 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
+scheduler@^0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.17.0.tgz#7c9c673e4ec781fac853927916d1c426b6f3ddfe"
+  integrity sha512-7rro8Io3tnCPuY4la/NuI5F2yfESpnfZyT6TtkXnSWVkcu0BCDJ+8gk5ozUaFaxpIyNuWAPXrH0yFcSi28fnDA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 schema-utils@^0.4.4:
   version "0.4.7"
@@ -5742,6 +6564,13 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-support@^0.4.15:
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
+  integrity sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==
+  dependencies:
+    source-map "^0.5.6"
+
 source-map-support@~0.5.6:
   version "0.5.10"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.10.tgz#2214080bc9d51832511ee2bab96e3c2f9353120c"
@@ -5755,7 +6584,7 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
-source-map@^0.5.6, source-map@~0.5.0:
+source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
@@ -5964,6 +6793,11 @@ stringify-package@^1.0.0:
   resolved "https://registry.yarnpkg.com/stringify-package/-/stringify-package-1.0.0.tgz#e02828089333d7d45cd8c287c30aa9a13375081b"
   integrity sha512-JIQqiWmLiEozOC0b0BtxZ/AOUtdUZHCBPgqIZ2kSJJqGwgb9neo44XdTHUC4HZSGqi03hOeB7W/E8rAlKnGe9g==
 
+stringify-package@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/stringify-package/-/stringify-package-1.0.1.tgz#e5aa3643e7f74d0f28628b72f3dad5cecfc3ba85"
+  integrity sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==
+
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
@@ -6069,7 +6903,7 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
-tar@^4.4.10, tar@^4.4.12:
+tar@^4.4.10, tar@^4.4.12, tar@^4.4.13:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
@@ -6164,6 +6998,11 @@ to-arraybuffer@^1.0.0:
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
   integrity sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=
 
+to-fast-properties@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+  integrity sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=
+
 to-object-path@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
@@ -6201,6 +7040,11 @@ tough-cookie@~2.4.3:
   dependencies:
     psl "^1.1.24"
     punycode "^1.4.1"
+
+trim-right@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+  integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
 tslib@^1.9.0:
   version "1.9.3"
@@ -6433,6 +7277,11 @@ uuid@^3.0.1, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
+uuid@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
+  integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
 
 v8-compile-cache@^2.0.2:
   version "2.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,36 @@
 # yarn lockfile v1
 
 
+"@fortawesome/fontawesome-common-types@^0.2.25":
+  version "0.2.25"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.25.tgz#6df015905081f2762e5cfddeb7a20d2e9b16c786"
+  integrity sha512-3RuZPDuuPELd7RXtUqTCfed14fcny9UiPOkdr2i+cYxBoTOfQgxcDoq77fHiiHcgWuo1LoBUpvGxFF1H/y7s3Q==
+
 "@fortawesome/fontawesome-free@^5.11.2":
   version "5.11.2"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.11.2.tgz#8644bc25b19475779a7b7c1fc104bc0a794f4465"
   integrity sha512-XiUPoS79r1G7PcpnNtq85TJ7inJWe0v+b5oZJZKb0pGHNIV6+UiNeQWiFGmuQ0aj7GEhnD/v9iqxIsjuRKtEnQ==
+
+"@fortawesome/fontawesome-svg-core@^1.2.25":
+  version "1.2.25"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.25.tgz#24b03391d14f0c6171e8cad7057c687b74049790"
+  integrity sha512-MotKnn53JKqbkLQiwcZSBJVYtTgIKFbh7B8+kd05TSnfKYPFmjKKI59o2fpz5t0Hzl35vVGU6+N4twoOpZUrqA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.25"
+
+"@fortawesome/free-solid-svg-icons@^5.11.2":
+  version "5.11.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.11.2.tgz#2f2f1459743a27902b76655a0d0bc5ec4d945631"
+  integrity sha512-zBue4i0PAZJUXOmLBBvM7L0O7wmsDC8dFv9IhpW5QL4kT9xhhVUsYg/LX1+5KaukWq4/cbDcKT+RT1aRe543sg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.25"
+
+"@fortawesome/react-fontawesome@^0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.7.tgz#c004ca75c15c5a1218101e8f042b8da8dec0c4b5"
+  integrity sha512-AHWSzOsHBe5vqOkrvs+CKw+8eLl+0XZsVixOWhTPpGpOA8WQUbVU6J9cmtAvTaxUU5OIf+rgxxF8ZKc3BVldxg==
+  dependencies:
+    prop-types "^15.5.10"
 
 "@webassemblyjs/ast@1.7.11":
   version "1.7.11"
@@ -5680,7 +5706,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.6.2:
+prop-types@^15.5.10, prop-types@^15.6.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==


### PR DESCRIPTION
This is a somewhat substantial frontend refactor with the main goals of:

1. Eliminating the use of jQuery function chains to construct html markup. This practice makes it difficult to understand what the resulting markup will be, as well as making it tricky to maintain and modify correctly.
2. Minimizing duplication of code via reusable, shared components/modules. In particular there was a significant amount of identical code in the gmail and roundcube content scripts which can now be maintained in a single location.

I've chosen to use React for component rendering, but because React has a bit of a learning curve and can be a stumbling block for developers unfamiliar with it, I've taken a conservative approach, and I (mostly) use it as a template language to render static markup. The exception is ReportEmailButton, which encapsulates its own state and behaviors so they can be easily shared between gmail and roundcube. The next logical step from here would be to create similar stateful React components for the popup, options, and apikey UI pages, assuming we want to continue further down this road. It would also be possible to swap in a different rendering system at this point, if preferred.